### PR TITLE
Add optional metadata streaming support to WaitOperation function

### DIFF
--- a/lro/example_test.go
+++ b/lro/example_test.go
@@ -1,12 +1,13 @@
 package lro
 
 import (
-	"cloud.google.com/go/longrunning/autogen/longrunningpb"
 	"context"
 	"fmt"
+	"time"
+
+	"cloud.google.com/go/longrunning/autogen/longrunningpb"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
-	"time"
 )
 
 func ExampleNewClient() {
@@ -34,9 +35,23 @@ func ExampleNewClient() {
 		}
 	}(op.Name)
 
-	// wait for a long-running op to finish
+	// wait for a long-running op to finish with a callback that prints incoming metadata
 	req := &longrunningpb.WaitOperationRequest{Name: op.Name, Timeout: durationpb.New(10 * time.Second)}
-	operation, _ := lroClient.WaitOperation(ctx, req)
+	metadataHandler := func(metadata *anypb.Any) {
+		// Assuming the metadata is a protobuf message, you can unmarshal it into a specific type
+		// Replace `YourMetadataMessageType` with the actual type of your metadata message.
+		//var metadataMsg {YourMetadataMessageType}
+		//if err := anypb.UnmarshalTo(metadata, metadataMsg, nil); err != nil {
+		//	// Handle unmarshaling error
+		//	log.Println("Failed to unmarshal metadata:", err)
+		//	return
+		//}
+		//
+		//// Process the metadata as needed
+		//log.Println("Received metadata:", metadataMsg)
+		return
+	}
+	operation, _ := lroClient.WaitOperation(ctx, req, metadataHandler)
 	if operation.Done != true {
 		println("operation is not done yet")
 	}

--- a/lro/lro.go
+++ b/lro/lro.go
@@ -29,6 +29,15 @@ func (e ErrNotFound) Error() string {
 	return fmt.Sprintf("%s not found", e.Operation)
 }
 
+// ErrWaitDeadlineExceeded is returned when the WaitOperation exceeds the specified, or default, timeout
+type ErrWaitDeadlineExceeded struct {
+	timeout *durationpb.Duration
+}
+
+func (e ErrWaitDeadlineExceeded) Error() string {
+	return fmt.Sprintf("exceeded timeout deadline of %d seconds", e.timeout.GetSeconds())
+}
+
 type InvalidOperationName struct {
 	Name string // unavailable locations
 }
@@ -130,7 +139,7 @@ func (c *Client) WaitOperation(ctx context.Context, req *longrunningpb.WaitOpera
 
 		timePassed := time.Now().Sub(startTime)
 		if timeout != nil && timePassed > duration {
-			return op, nil
+			return nil, ErrWaitDeadlineExceeded{timeout: timeout}
 		}
 		time.Sleep(1 * time.Second)
 	}

--- a/lro/lro.go
+++ b/lro/lro.go
@@ -17,8 +17,11 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-const ColumnFamily = "0"
-const ParentlessOpColumn = "0"
+// Bigtable constants
+const (
+	ColumnFamily       = "0"
+	ParentlessOpColumn = "0"
+)
 
 // ErrNotFound is returned when the requested operation does not exist in bigtable
 type ErrNotFound struct {

--- a/lro/lro_test.go
+++ b/lro/lro_test.go
@@ -1,20 +1,21 @@
 package lro
 
 import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"testing"
+
 	"cloud.google.com/go/bigtable"
 	"cloud.google.com/go/bigtable/bttest"
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
-	"context"
-	"fmt"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
-	"log"
-	"strconv"
-	"testing"
 )
 
 const tableName = "test"
@@ -375,7 +376,6 @@ func TestClient_WaitOperation(t *testing.T) {
 				ctx:           context.Background(),
 				operationName: "operations/test-id-3",
 				timeout:       -1, //negative nummber to indicate to test that no timeout is set
-
 			},
 			want: &longrunningpb.Operation{
 				Name:     "operations/test-id-3",
@@ -394,7 +394,7 @@ func TestClient_WaitOperation(t *testing.T) {
 				req = &longrunningpb.WaitOperationRequest{Name: tt.args.operationName}
 			}
 
-			got, err := lro.WaitOperation(tt.args.ctx, req)
+			got, err := lro.WaitOperation(tt.args.ctx, req, nil)
 			if err != nil {
 				t.Errorf("WaitOperation() error = %v", err)
 			}


### PR DESCRIPTION
## Description
This pull request introduces an enhancement to the existing `WaitOperation` function in the package. It adds the ability to stream metadata to the caller through an optional callback function.

## Changes Made

1. Updated the `WaitOperation` function signature to include an optional `metadataCallback` parameter of type `func(*anypb.Any)`.
2. Modified the `WaitOperation` function implementation to invoke the `metadataCallback` if provided and the operation contains metadata.

## Benefits
The addition of optional metadata streaming support brings the following benefits:

1. **Flexible Metadata Handling**: By providing a callback function, users can now receive and process metadata associated with long-running operations. This enables them to extract relevant information and take appropriate actions while waiting for the operation to complete.
2. **Customisable Metadata Processing**: The callback function allows users to define their own logic to handle the received metadata. They can unmarshal the metadata into specific types, perform validation, and use the information as needed.
3. **Improved Observability**: Streaming metadata enables better observability during long-running operations. Users can access real-time updates and monitor the progress of the operation, enabling them to track critical details or make informed decisions based on the metadata received.
4. **Enhanced User Experience**: With the addition of metadata streaming, users can now have more control and visibility over the operation's progress. They can implement progress indicators, display informative messages, or provide real-time status updates to end-users or monitoring systems.