### PR TITLE
feat(evals): add support for server and client streaming RPCs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ key**.json
 .vscode
 .cursor
 .idea
+coverage.out
+**/coverage.out

--- a/evals/README.md
+++ b/evals/README.md
@@ -20,6 +20,7 @@ Pub/Sub or BigQuery pin that module directly.
 2. [Concepts](#concepts)
 3. [Wire types](#wire-types)
 4. [Integration tests](#integration-tests)
+   - [Streaming RPCs](#streaming-rpcs)
 5. [Agent evaluations](#agent-evaluations)
 6. [Load tests](#load-tests)
 7. [Options reference](#options-reference)
@@ -353,6 +354,90 @@ t.Check("shape", r.Resp.GetName() != "")
 outcomes.
 
 **StopOnFailure.** For stateful flows (create → get → update → delete), `evals.StopOnFailure()` on the suite marks all subsequent cases `NOT_EVALUATED` once any case fails.
+
+### Streaming RPCs
+
+**When to use which helper:**
+
+- **Unary `Call`** — single request/response RPCs (and client-streaming when split timing is not needed).
+- **`CallServerStream`** — bounded server-streaming RPCs that terminate with EOF.
+- **`CallClientStream`** — client-streaming RPCs where send-side vs response-side timing matters.
+
+Use `evals.CallServerStream` for bounded server-streaming RPCs. The helper drains messages until EOF or error and captures TTFB, total duration, and inter-message gaps uniformly:
+
+```go
+res := evals.CallServerStream(ctx, func(ctx context.Context) (grpc.ServerStreamingClient[examplepb.Event], error) {
+    return clients.Example.WatchEvents(ctx, req)
+})
+if !t.NoErr("grpc", res.Err) { return }
+if len(res.Messages) > 0 {
+    t.Max("ttfb", res.TTFB, 100*time.Millisecond)
+}
+t.Max("total", res.TotalDuration, 2*time.Second)
+t.Check("count", len(res.Messages) == 5)
+// MessageIntervals[i] spans Messages[i] → Messages[i+1]; length is max(0, len(Messages)-1).
+if len(res.MessageIntervals) > 0 {
+    t.Max("gap-0", res.MessageIntervals[0], 500*time.Millisecond)
+}
+```
+
+**TTFB is 0 when no message is received** — always guard with `len(res.Messages) > 0` before asserting on TTFB. TTFB includes stream-open cost (client-perceived latency).
+
+**Do not use `CallServerStream` on watch/subscribe RPCs that never send EOF** — the call blocks until context cancellation. Use a context deadline to bound execution.
+
+If `Recv` returns a nil message with nil error, `Err` is set and any messages received so far are preserved.
+
+Use `evals.CallClientStream` for client-streaming RPCs when you need split send vs response timing:
+
+```go
+r := evals.CallClientStream(ctx,
+    func(ctx context.Context) (grpc.ClientStreamingClient[examplepb.Chunk, examplepb.UploadResult], error) {
+        return clients.Example.Upload(ctx)
+    },
+    func(stream grpc.ClientStreamingClient[examplepb.Chunk, examplepb.UploadResult]) (examplepb.UploadResult, error) {
+        for _, chunk := range chunks {
+            if err := stream.Send(chunk); err != nil {
+                return examplepb.UploadResult{}, err
+            }
+        }
+        resp, err := stream.CloseAndRecv()
+        if err != nil {
+            return examplepb.UploadResult{}, err
+        }
+        return *resp, nil
+    },
+)
+if !t.NoErr("grpc", r.Err) { return }
+t.Max("send", r.SendDuration, 500*time.Millisecond)
+t.Max("response", r.ResponseLatency, 200*time.Millisecond)
+```
+
+**`SendDuration` includes `openFn` cost** (consistent with server TTFB). **`ResponseLatency` is 0** when `CloseAndRecv` was never reached (for example after a send error).
+
+`TotalDuration` may exceed `SendDuration + ResponseLatency` because overhead between the last `Send` and `CloseAndRecv` is author code, not stream I/O. Unary `Call` remains appropriate when split timing is not needed.
+
+#### Result types
+
+**`ServerStreamResult[T]`**
+
+| Field | Meaning |
+| ----- | ------- |
+| `Messages` | All successfully received messages (partial on recv error). |
+| `Err` | Transport error; nil on clean EOF. Set on nil-message `Recv`. |
+| `TTFB` | Start through first message; includes `openFn`. **0 when empty.** |
+| `TotalDuration` | Wall clock from start through recv loop exit. |
+| `MessageIntervals` | Gap between consecutive messages; `len = max(0, len(Messages)-1)`. |
+
+**`ClientStreamResult[Resp]`**
+
+| Field | Meaning |
+| ----- | ------- |
+| `Resp` | Final response from `sendFn` (partial value preserved on error). |
+| `Err` | Transport or sendFn error. |
+| `SendDuration` | Start through last successful Send (includes `openFn`). |
+| `ResponseLatency` | `CloseAndRecv` entry through return; 0 if never reached. |
+| `TotalDuration` | Wall clock through `sendFn` return. |
+| `MessagesSent` | Count of successful Sends. |
 
 ---
 
@@ -922,6 +1007,10 @@ to a gRPC status by the RPC handlers.
 | Function                                                                            | Purpose                                                                                                                 |
 | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `evals.Call[T](ctx context.Context, fn func(context.Context) (T, error)) Result[T]` | Invoke an RPC, capture typed response, error, and wall-clock latency. Records nothing on `T` — assertions are explicit. |
+| `evals.CallServerStream[T](ctx, openFn) ServerStreamResult[T]` | Drain a bounded server stream; capture messages, TTFB (0 when empty), total duration, and inter-message intervals. |
+| `evals.CallClientStream[Req, Resp](ctx, openFn, sendFn) ClientStreamResult[Resp]` | Client-streaming with split send/response timing and message count. |
+| `evals.ServerStreamResult[T]` | `{Messages []T, Err, TTFB, TotalDuration, MessageIntervals}`. |
+| `evals.ClientStreamResult[Resp]` | `{Resp, Err, SendDuration, ResponseLatency, TotalDuration, MessagesSent}`. |
 | `evals.Result[T]`                                                                   | `{Resp T, Err error, Latency time.Duration}`.                                                                           |
 | `evals.Rouge1F1(hypothesis, reference string) float64`                              | Deterministic ROUGE-1 unigram F1 scorer. Empty-empty → 1; one-empty → 0. Feed into `t.Score`.                           |
 | `evals.DefaultLoadProfile(mode evalspb.RunLoadTestRequest_Mode) (Profile, bool)`    | Look up the framework default profile for `mode`. Returns `(zero, false)` for `MODE_UNSPECIFIED`.                       |
@@ -1013,7 +1102,7 @@ callers pass into their own token source when building the transport.
 
 | Path                    | Role                                                                                                                                     |
 | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `evals`                 | Public authoring surface: `NewIntegrationSuite`, `NewAgentEvalSuite`, `NewLoadSuite`, `T`, `Call`, `Rouge1F1`, SLO constructors, registration functions. |
+| `evals`                 | Public authoring surface: `NewIntegrationSuite`, `NewAgentEvalSuite`, `NewLoadSuite`, `T`, `Call`, `CallServerStream`, `CallClientStream`, `Rouge1F1`, SLO constructors, registration functions. See also `stream_server.go` and `stream_client.go`. |
 | `evals/adk`             | ADK evaluation-launcher client (transport-agnostic) and lazy `AgentEvalProvider`.                                                        |
 | `evals/env`             | Shared environment registration and activation.                                                                                          |
 | `evals/errors`          | `EvalError` interface + `ToGRPC` / `ToGRPCf` for RPC boundary translation.                                                               |

--- a/evals/adk/agent.go
+++ b/evals/adk/agent.go
@@ -2,7 +2,6 @@ package adk
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"go.alis.build/adk/launchers/evals/evaluation/models"
 )
@@ -102,11 +101,11 @@ func RubricBasedFinalResponseQualityV1(threshold float64, rubrics []models.Rubri
 func metricFromJSON(v any) (models.EvalMetric, error) {
 	raw, err := json.Marshal(v)
 	if err != nil {
-		return models.EvalMetric{}, fmt.Errorf("adk: encode metric: %w", err)
+		return models.EvalMetric{}, ErrEncodeMetric{Err: err}
 	}
 	var m models.EvalMetric
 	if err := json.Unmarshal(raw, &m); err != nil {
-		return models.EvalMetric{}, fmt.Errorf("adk: decode metric: %w", err)
+		return models.EvalMetric{}, ErrDecodeMetric{Err: err}
 	}
 	return m, nil
 }

--- a/evals/adk/client.go
+++ b/evals/adk/client.go
@@ -133,7 +133,7 @@ func NewHTTPClient(baseURL string, opts ...HTTPClientOption) *HTTPClient {
 // RunEval POSTs to .../eval_sets/{evalSetId}/run_eval and decodes results.
 func (c *HTTPClient) RunEval(ctx context.Context, params RunEvalParams) ([]models.RunEvalResult, error) {
 	if c == nil {
-		return nil, fmt.Errorf("adk client: nil client")
+		return nil, ErrNilClient{}
 	}
 	baseURL := params.BaseURL
 	if baseURL == "" {
@@ -144,7 +144,7 @@ func (c *HTTPClient) RunEval(ctx context.Context, params RunEvalParams) ([]model
 		pathPrefix = c.pathPrefix
 	}
 	if params.AppName == "" || params.EvalSetID == "" {
-		return nil, fmt.Errorf("adk client: app name and eval set id are required")
+		return nil, ErrMissingAppNameEvalSetID{}
 	}
 
 	body, err := json.Marshal(runEvalRequest{
@@ -152,7 +152,7 @@ func (c *HTTPClient) RunEval(ctx context.Context, params RunEvalParams) ([]model
 		EvalMetrics: params.Metrics,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("adk client: encode request: %w", err)
+		return nil, ErrEncodeRequest{Err: err}
 	}
 
 	url := fmt.Sprintf("%s%s/dev/apps/%s/eval_sets/%s/run_eval",
@@ -164,27 +164,30 @@ func (c *HTTPClient) RunEval(ctx context.Context, params RunEvalParams) ([]model
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("adk client: build request: %w", err)
+		return nil, ErrBuildRequest{Err: err}
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrAgentUnreachable, err)
+		return nil, ErrAgentUnreachable{Cause: err}
 	}
 	defer resp.Body.Close()
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("adk client: read response: %w", err)
+		return nil, ErrReadResponse{Err: err}
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("%w: status %d: %s", ErrRunEvalFailed, resp.StatusCode, strings.TrimSpace(string(raw)))
+		return nil, ErrRunEvalFailed{
+			StatusCode: resp.StatusCode,
+			Body:       strings.TrimSpace(string(raw)),
+		}
 	}
 
 	results, err := decodeRunEvalResults(raw)
 	if err != nil {
-		return nil, fmt.Errorf("adk client: decode response: %w", err)
+		return nil, ErrDecodeResponse{Err: err}
 	}
 	return results, nil
 }
@@ -192,10 +195,10 @@ func (c *HTTPClient) RunEval(ctx context.Context, params RunEvalParams) ([]model
 // ListEvalSets GETs .../eval_sets and decodes eval set ids for an app.
 func (c *HTTPClient) ListEvalSets(ctx context.Context, appName string) ([]string, error) {
 	if c == nil {
-		return nil, fmt.Errorf("adk client: nil client")
+		return nil, ErrNilClient{}
 	}
 	if appName == "" {
-		return nil, fmt.Errorf("adk client: app name is required")
+		return nil, ErrMissingAppName{}
 	}
 
 	url := fmt.Sprintf("%s%s/dev/apps/%s/eval_sets",
@@ -206,21 +209,24 @@ func (c *HTTPClient) ListEvalSets(ctx context.Context, appName string) ([]string
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("adk client: build request: %w", err)
+		return nil, ErrBuildRequest{Err: err}
 	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrAgentUnreachable, err)
+		return nil, ErrAgentUnreachable{Cause: err}
 	}
 	defer resp.Body.Close()
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("adk client: read response: %w", err)
+		return nil, ErrReadResponse{Err: err}
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("%w: status %d: %s", ErrRunEvalFailed, resp.StatusCode, strings.TrimSpace(string(raw)))
+		return nil, ErrRunEvalFailed{
+			StatusCode: resp.StatusCode,
+			Body:       strings.TrimSpace(string(raw)),
+		}
 	}
 
 	trimmed := bytes.TrimSpace(raw)
@@ -230,7 +236,7 @@ func (c *HTTPClient) ListEvalSets(ctx context.Context, appName string) ([]string
 
 	var ids []string
 	if err := json.Unmarshal(trimmed, &ids); err != nil {
-		return nil, fmt.Errorf("adk client: decode eval sets: %w", err)
+		return nil, ErrDecodeEvalSets{Err: err}
 	}
 	return ids, nil
 }

--- a/evals/adk/errors.go
+++ b/evals/adk/errors.go
@@ -1,10 +1,341 @@
 package adk
 
-import "errors"
+import (
+	"errors"
+	"fmt"
 
-var (
-	// ErrRunEvalFailed indicates the launcher returned a non-success HTTP status.
-	ErrRunEvalFailed = errors.New("adk: run eval failed")
-	// ErrAgentUnreachable indicates the HTTP request could not complete.
-	ErrAgentUnreachable = errors.New("adk: agent unreachable")
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// ErrRunEvalFailed indicates the launcher returned a non-success HTTP status.
+type ErrRunEvalFailed struct {
+	StatusCode int
+	Body       string
+}
+
+func (e ErrRunEvalFailed) Error() string {
+	return fmt.Sprintf("adk: run eval failed: status %d: %s", e.StatusCode, e.Body)
+}
+
+func (e ErrRunEvalFailed) Is(target error) bool {
+	var err ErrRunEvalFailed
+	return errors.As(target, &err)
+}
+
+func (e ErrRunEvalFailed) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrAgentUnreachable indicates the HTTP request could not complete.
+type ErrAgentUnreachable struct {
+	Cause error
+}
+
+func (e ErrAgentUnreachable) Error() string {
+	if e.Cause == nil {
+		return "adk: agent unreachable"
+	}
+	return fmt.Sprintf("adk: agent unreachable: %v", e.Cause)
+}
+
+func (e ErrAgentUnreachable) Unwrap() error { return e.Cause }
+
+func (e ErrAgentUnreachable) Is(target error) bool {
+	var err ErrAgentUnreachable
+	return errors.As(target, &err) || errors.Is(e.Cause, target)
+}
+
+func (e ErrAgentUnreachable) GRPCStatus() *status.Status {
+	return status.New(codes.Unavailable, e.Error())
+}
+
+// ErrNilClient is returned when an ADK HTTP client method is invoked on a
+// nil receiver.
+type ErrNilClient struct{}
+
+func (e ErrNilClient) Error() string { return "adk client: nil client" }
+
+func (e ErrNilClient) Is(target error) bool {
+	var err ErrNilClient
+	return errors.As(target, &err)
+}
+
+func (e ErrNilClient) GRPCStatus() *status.Status {
+	return status.New(codes.FailedPrecondition, e.Error())
+}
+
+// ErrMissingAppNameEvalSetID is returned when RunEval is called without an
+// app name or eval set id.
+type ErrMissingAppNameEvalSetID struct{}
+
+func (e ErrMissingAppNameEvalSetID) Error() string {
+	return "adk client: app name and eval set id are required"
+}
+
+func (e ErrMissingAppNameEvalSetID) Is(target error) bool {
+	var err ErrMissingAppNameEvalSetID
+	return errors.As(target, &err)
+}
+
+func (e ErrMissingAppNameEvalSetID) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrMissingAppName is returned when ListEvalSets is called without an app name.
+type ErrMissingAppName struct{}
+
+func (e ErrMissingAppName) Error() string { return "adk client: app name is required" }
+
+func (e ErrMissingAppName) Is(target error) bool {
+	var err ErrMissingAppName
+	return errors.As(target, &err)
+}
+
+func (e ErrMissingAppName) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrNilProvider is returned when Provider.Run is called on a nil receiver.
+type ErrNilProvider struct{}
+
+func (e ErrNilProvider) Error() string { return "adk provider: nil provider" }
+
+func (e ErrNilProvider) Is(target error) bool {
+	var err ErrNilProvider
+	return errors.As(target, &err)
+}
+
+func (e ErrNilProvider) GRPCStatus() *status.Status {
+	return status.New(codes.FailedPrecondition, e.Error())
+}
+
+// ErrMissingProviderConfig is returned when Provider.Run is called without
+// a base URL or app name.
+type ErrMissingProviderConfig struct{}
+
+func (e ErrMissingProviderConfig) Error() string {
+	return "adk provider: base URL and app name are required"
+}
+
+func (e ErrMissingProviderConfig) Is(target error) bool {
+	var err ErrMissingProviderConfig
+	return errors.As(target, &err)
+}
+
+func (e ErrMissingProviderConfig) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrEmptyBaseURL is returned when a base URL is empty after normalisation.
+type ErrEmptyBaseURL struct{}
+
+func (e ErrEmptyBaseURL) Error() string { return "adk: empty base URL" }
+
+func (e ErrEmptyBaseURL) Is(target error) bool {
+	var err ErrEmptyBaseURL
+	return errors.As(target, &err)
+}
+
+func (e ErrEmptyBaseURL) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrInvalidBaseURL is returned when a base URL cannot yield a host.
+type ErrInvalidBaseURL struct {
+	URL string
+}
+
+func (e ErrInvalidBaseURL) Error() string {
+	return fmt.Sprintf("adk: invalid base URL %q", e.URL)
+}
+
+func (e ErrInvalidBaseURL) Is(target error) bool {
+	var err ErrInvalidBaseURL
+	return errors.As(target, &err)
+}
+
+func (e ErrInvalidBaseURL) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrEncodeRequest wraps a failure to encode an ADK HTTP request body.
+type ErrEncodeRequest struct {
+	Err error
+}
+
+func (e ErrEncodeRequest) Error() string {
+	return fmt.Sprintf("adk client: encode request: %v", e.Err)
+}
+
+func (e ErrEncodeRequest) Unwrap() error { return e.Err }
+
+func (e ErrEncodeRequest) Is(target error) bool {
+	var err ErrEncodeRequest
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrEncodeRequest) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrBuildRequest wraps a failure to construct an ADK HTTP request.
+type ErrBuildRequest struct {
+	Err error
+}
+
+func (e ErrBuildRequest) Error() string {
+	return fmt.Sprintf("adk client: build request: %v", e.Err)
+}
+
+func (e ErrBuildRequest) Unwrap() error { return e.Err }
+
+func (e ErrBuildRequest) Is(target error) bool {
+	var err ErrBuildRequest
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrBuildRequest) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrReadResponse wraps a failure to read an ADK HTTP response body.
+type ErrReadResponse struct {
+	Err error
+}
+
+func (e ErrReadResponse) Error() string {
+	return fmt.Sprintf("adk client: read response: %v", e.Err)
+}
+
+func (e ErrReadResponse) Unwrap() error { return e.Err }
+
+func (e ErrReadResponse) Is(target error) bool {
+	var err ErrReadResponse
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrReadResponse) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrDecodeResponse wraps a failure to decode an ADK run_eval response.
+type ErrDecodeResponse struct {
+	Err error
+}
+
+func (e ErrDecodeResponse) Error() string {
+	return fmt.Sprintf("adk client: decode response: %v", e.Err)
+}
+
+func (e ErrDecodeResponse) Unwrap() error { return e.Err }
+
+func (e ErrDecodeResponse) Is(target error) bool {
+	var err ErrDecodeResponse
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrDecodeResponse) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrDecodeEvalSets wraps a failure to decode an ADK eval set list response.
+type ErrDecodeEvalSets struct {
+	Err error
+}
+
+func (e ErrDecodeEvalSets) Error() string {
+	return fmt.Sprintf("adk client: decode eval sets: %v", e.Err)
+}
+
+func (e ErrDecodeEvalSets) Unwrap() error { return e.Err }
+
+func (e ErrDecodeEvalSets) Is(target error) bool {
+	var err ErrDecodeEvalSets
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrDecodeEvalSets) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrEncodeMetric wraps a failure to encode an eval metric for the ADK API.
+type ErrEncodeMetric struct {
+	Err error
+}
+
+func (e ErrEncodeMetric) Error() string {
+	return fmt.Sprintf("adk: encode metric: %v", e.Err)
+}
+
+func (e ErrEncodeMetric) Unwrap() error { return e.Err }
+
+func (e ErrEncodeMetric) Is(target error) bool {
+	var err ErrEncodeMetric
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrEncodeMetric) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrDecodeMetric wraps a failure to decode an eval metric from the ADK API.
+type ErrDecodeMetric struct {
+	Err error
+}
+
+func (e ErrDecodeMetric) Error() string {
+	return fmt.Sprintf("adk: decode metric: %v", e.Err)
+}
+
+func (e ErrDecodeMetric) Unwrap() error { return e.Err }
+
+func (e ErrDecodeMetric) Is(target error) bool {
+	var err ErrDecodeMetric
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrDecodeMetric) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrListEvalSets wraps a failure to list eval sets from the ADK launcher.
+type ErrListEvalSets struct {
+	Err error
+}
+
+func (e ErrListEvalSets) Error() string {
+	return fmt.Sprintf("list eval sets: %v", e.Err)
+}
+
+func (e ErrListEvalSets) Unwrap() error { return e.Err }
+
+func (e ErrListEvalSets) Is(target error) bool {
+	var err ErrListEvalSets
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrListEvalSets) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrRunEval wraps a failure to run an eval set via the ADK launcher.
+type ErrRunEval struct {
+	SetID string
+	Err   error
+}
+
+func (e ErrRunEval) Error() string {
+	return fmt.Sprintf("run_eval %s: %v", e.SetID, e.Err)
+}
+
+func (e ErrRunEval) Unwrap() error { return e.Err }
+
+func (e ErrRunEval) Is(target error) bool {
+	var err ErrRunEval
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrRunEval) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}

--- a/evals/adk/provider.go
+++ b/evals/adk/provider.go
@@ -2,7 +2,6 @@ package adk
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"go.alis.build/evals/execution"
@@ -50,10 +49,10 @@ func NewProvider(agent Agent, opts ...ProviderOption) *Provider {
 // Run discovers eval sets, runs filtered cases, and returns suite results.
 func (p *Provider) Run(ctx context.Context, filters []string) ([]execution.SuiteResult, error) {
 	if p == nil {
-		return nil, fmt.Errorf("adk provider: nil provider")
+		return nil, ErrNilProvider{}
 	}
 	if p.agent.BaseURL == "" || p.agent.AppName == "" {
-		return nil, fmt.Errorf("adk provider: base URL and app name are required")
+		return nil, ErrMissingProviderConfig{}
 	}
 
 	client, err := p.newClient(ctx, p.agent.BaseURL, p.agent.pathPrefix())
@@ -63,7 +62,7 @@ func (p *Provider) Run(ctx context.Context, filters []string) ([]execution.Suite
 
 	setIDs, err := client.ListEvalSets(ctx, p.agent.AppName)
 	if err != nil {
-		return nil, fmt.Errorf("list eval sets: %w", err)
+		return nil, ErrListEvalSets{Err: err}
 	}
 
 	parsed, err := suite.ParseFilterPaths(filters)
@@ -95,7 +94,7 @@ func (p *Provider) Run(ctx context.Context, filters []string) ([]execution.Suite
 		results, err := client.RunEval(ctx, params)
 		end := time.Now()
 		if err != nil {
-			return nil, fmt.Errorf("run_eval %s: %w", setID, err)
+			return nil, ErrRunEval{SetID: setID, Err: err}
 		}
 
 		each := end.Sub(start) / time.Duration(max(len(results), 1))

--- a/evals/adk/url.go
+++ b/evals/adk/url.go
@@ -1,7 +1,6 @@
 package adk
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -22,7 +21,7 @@ func hostFromBaseURL(baseURL string) (string, error) {
 	s = strings.TrimPrefix(s, "https://")
 	s = strings.TrimPrefix(s, "http://")
 	if s == "" {
-		return "", fmt.Errorf("adk: empty base URL")
+		return "", ErrEmptyBaseURL{}
 	}
 	if i := strings.IndexByte(s, '/'); i >= 0 {
 		s = s[:i]
@@ -31,7 +30,7 @@ func hostFromBaseURL(baseURL string) (string, error) {
 		s = s[:i]
 	}
 	if s == "" {
-		return "", fmt.Errorf("adk: invalid base URL %q", baseURL)
+		return "", ErrInvalidBaseURL{URL: baseURL}
 	}
 	return s, nil
 }

--- a/evals/doc.go
+++ b/evals/doc.go
@@ -30,10 +30,10 @@
 //
 // # Integration tests
 //
-// An integration case is a func(ctx, *T) that measures the SUT with [Call]
-// and records assertions on [T]. Every recording method on T returns
-// whether the leaf passed, so authors guard-and-return without any custom
-// flow control:
+// An integration case is a func(ctx, *T) that measures the SUT with [Call],
+// [CallServerStream], or [CallClientStream] and records assertions on [T].
+// Every recording method on T returns whether the leaf passed, so authors
+// guard-and-return without any custom flow control:
 //
 //	func Register() {
 //	    s := evals.MustNewIntegrationSuite("example-v1",
@@ -55,6 +55,54 @@
 //	        panic(err)
 //	    }
 //	}
+//
+// For server-streaming RPCs, use [CallServerStream] to drain a bounded stream
+// and capture TTFB, total duration, and inter-message gaps. TTFB is 0 when
+// no message is received — guard before asserting:
+//
+//	res := evals.CallServerStream(ctx, func(ctx context.Context) (grpc.ServerStreamingClient[Event], error) {
+//	    return clients.Foo.Watch(ctx, req)
+//	})
+//	if !t.NoErr("grpc", res.Err) { return }
+//	if len(res.Messages) > 0 {
+//	    t.Max("ttfb", res.TTFB, 100*time.Millisecond)
+//	}
+//	t.Max("total", res.TotalDuration, 2*time.Second)
+//	// MessageIntervals[i] is the gap between Messages[i] and Messages[i+1].
+//
+// Do not use [CallServerStream] on watch RPCs that never send EOF; use a
+// context deadline to bound execution. If Recv returns a nil message with
+// nil error, Err is set and partial messages are preserved.
+//
+// For client-streaming RPCs, use [CallClientStream] when send-side vs
+// response-side timing matters. [Call] remains appropriate for unary-shaped
+// client streams when split timing is not needed.
+//
+//	r := evals.CallClientStream(ctx,
+//	    func(ctx context.Context) (grpc.ClientStreamingClient[Chunk, UploadResult], error) {
+//	        return clients.Example.Upload(ctx)
+//	    },
+//	    func(stream grpc.ClientStreamingClient[Chunk, UploadResult]) (UploadResult, error) {
+//	        for _, chunk := range chunks {
+//	            if err := stream.Send(chunk); err != nil {
+//	                return UploadResult{}, err
+//	            }
+//	        }
+//	        resp, err := stream.CloseAndRecv()
+//	        if err != nil {
+//	            return UploadResult{}, err
+//	        }
+//	        return *resp, nil
+//	    },
+//	)
+//	if !t.NoErr("grpc", r.Err) { return }
+//	t.Max("send", r.SendDuration, 500*time.Millisecond)
+//	t.Max("response", r.ResponseLatency, 200*time.Millisecond)
+//
+// SendDuration includes stream open. ResponseLatency is 0 when CloseAndRecv
+// was never reached (for example after a send error). TotalDuration may
+// exceed SendDuration + ResponseLatency because author code between the
+// last Send and CloseAndRecv is not attributed to either phase.
 //
 // # Agent evaluations
 //

--- a/evals/errors.go
+++ b/evals/errors.go
@@ -103,3 +103,37 @@ func (e ErrWrongSuiteKind) Is(target error) bool {
 func (e ErrWrongSuiteKind) GRPCStatus() *status.Status {
 	return status.New(codes.InvalidArgument, e.Error())
 }
+
+// ErrNilStream is returned when openFn succeeds but returns a nil stream
+// with a nil error.
+type ErrNilStream struct{}
+
+func (e ErrNilStream) Error() string {
+	return "evals: openFn returned nil stream"
+}
+
+func (e ErrNilStream) Is(target error) bool {
+	var err ErrNilStream
+	return errors.As(target, &err)
+}
+
+func (e ErrNilStream) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrNilStreamMessage is returned when Recv returns a nil message with a
+// nil error on a server stream.
+type ErrNilStreamMessage struct{}
+
+func (e ErrNilStreamMessage) Error() string {
+	return "evals: server stream Recv returned nil message"
+}
+
+func (e ErrNilStreamMessage) Is(target error) bool {
+	var err ErrNilStreamMessage
+	return errors.As(target, &err)
+}
+
+func (e ErrNilStreamMessage) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}

--- a/evals/errors/errors_test.go
+++ b/evals/errors/errors_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"go.alis.build/evals"
 	"go.alis.build/evals/registry"
 	"go.alis.build/evals/suite"
 	"google.golang.org/grpc/codes"
@@ -43,6 +44,19 @@ func TestIsEval(t *testing.T) {
 	}
 	if IsEval(errors.New("plain")) {
 		t.Fatal("plain error should not implement EvalError")
+	}
+}
+
+func TestIsEval_streamErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, err := range []error{
+		evals.ErrNilStream{},
+		evals.ErrNilStreamMessage{},
+	} {
+		if !IsEval(err) {
+			t.Fatalf("expected %T to implement EvalError", err)
+		}
 	}
 }
 

--- a/evals/example_test.go
+++ b/evals/example_test.go
@@ -2,10 +2,13 @@ package evals_test
 
 import (
 	"context"
+	"io"
 	"time"
 
 	evalspb "go.alis.build/common/alis/evals/v1"
 	"go.alis.build/evals"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 // fakeItem stands in for a caller's typed protobuf response so the examples
@@ -45,6 +48,101 @@ func ExampleCall() {
 	})
 	// evals.RegisterIntegration(s) — omitted to keep the example
 	// side-effect free.
+	_ = s
+}
+
+type exampleStreamBase struct {
+	ctx context.Context
+}
+
+func (b exampleStreamBase) Header() (metadata.MD, error) { return nil, nil }
+func (b exampleStreamBase) Trailer() metadata.MD         { return nil }
+func (b exampleStreamBase) CloseSend() error             { return nil }
+func (b exampleStreamBase) Context() context.Context {
+	if b.ctx != nil {
+		return b.ctx
+	}
+	return context.Background()
+}
+func (b exampleStreamBase) SendMsg(any) error { return nil }
+func (b exampleStreamBase) RecvMsg(any) error { return nil }
+
+type exampleServerStream struct {
+	exampleStreamBase
+	msgs []string
+	idx  int
+}
+
+func (s *exampleServerStream) Recv() (*string, error) {
+	if s.idx >= len(s.msgs) {
+		return nil, io.EOF
+	}
+	msg := s.msgs[s.idx]
+	s.idx++
+	return &msg, nil
+}
+
+type exampleClientStream struct {
+	exampleStreamBase
+}
+
+func (s *exampleClientStream) Send(*string) error { return nil }
+func (s *exampleClientStream) CloseAndRecv() (*string, error) {
+	resp := "ok"
+	return &resp, nil
+}
+
+// ExampleCallServerStream shows how to drain a bounded server stream and
+// assert on captured timing fields.
+func ExampleCallServerStream() {
+	s := evals.MustNewIntegrationSuite("example-v1")
+	s.MustCase("watch-events", func(ctx context.Context, t *evals.T) {
+		res := evals.CallServerStream(ctx, func(ctx context.Context) (grpc.ServerStreamingClient[string], error) {
+			return &exampleServerStream{
+				exampleStreamBase: exampleStreamBase{ctx: ctx},
+				msgs:              []string{"created", "updated"},
+			}, nil
+		})
+		if !t.NoErr("grpc", res.Err) {
+			return
+		}
+		if len(res.Messages) > 0 {
+			t.Max("ttfb", res.TTFB, time.Second)
+		}
+		t.Max("total", res.TotalDuration, time.Second)
+		// MessageIntervals[i] is the gap between Messages[i] and Messages[i+1].
+		t.Check("count", len(res.Messages) == 2)
+	})
+	_ = s
+}
+
+// ExampleCallClientStream shows client-streaming with split send and response timing.
+func ExampleCallClientStream() {
+	s := evals.MustNewIntegrationSuite("example-v1")
+	s.MustCase("upload", func(ctx context.Context, t *evals.T) {
+		r := evals.CallClientStream(ctx,
+			func(ctx context.Context) (grpc.ClientStreamingClient[string, string], error) {
+				return &exampleClientStream{exampleStreamBase: exampleStreamBase{ctx: ctx}}, nil
+			},
+			func(stream grpc.ClientStreamingClient[string, string]) (string, error) {
+				chunk := "data"
+				if err := stream.Send(&chunk); err != nil {
+					return "", err
+				}
+				resp, err := stream.CloseAndRecv()
+				if err != nil {
+					return "", err
+				}
+				return *resp, nil
+			},
+		)
+		if !t.NoErr("grpc", r.Err) {
+			return
+		}
+		t.Max("send", r.SendDuration, time.Second)
+		t.Max("response", r.ResponseLatency, time.Second)
+		t.Check("result", r.Resp == "ok")
+	})
 	_ = s
 }
 

--- a/evals/knowledge/api/helpers.md
+++ b/evals/knowledge/api/helpers.md
@@ -1,25 +1,29 @@
 ---
 type: API Reference
 title: Helpers
-description: Small utilities on the public authoring surface — `Call`, `Result[T]`, `Rouge1F1`, load-profile resolution.
+description: Small utilities on the public authoring surface — `Call`, streaming helpers, `Result[T]`, `Rouge1F1`, load-profile resolution.
 resource: https://github.com/alis-exchange/go-alis-build/blob/main/evals/call.go
-tags: [api, helpers, utility]
-timestamp: 2026-07-08T00:00:00Z
+tags: [api, helpers, utility, streaming]
+timestamp: 2026-07-14T00:00:00Z
 ---
 
 # Functions
 
 | Function | Purpose |
 | -------- | ------- |
-| `evals.Call[T](ctx context.Context, fn func(context.Context) (T, error)) Result[T]` | Invoke an RPC, capture typed response, error, and wall-clock latency. Records nothing on `T` — assertions are explicit. |
+| `evals.Call[T](ctx context.Context, fn func(context.Context) (T, error)) Result[T]` | Invoke a unary RPC, capture typed response, error, and wall-clock latency. Records nothing on `T` — assertions are explicit. |
+| `evals.CallServerStream[T](ctx, openFn) ServerStreamResult[T]` | Drain a bounded server stream; capture messages, TTFB (0 when empty), total duration, and inter-message intervals. |
+| `evals.CallClientStream[Req, Resp](ctx, openFn, sendFn) ClientStreamResult[Resp]` | Client-streaming with split send/response timing and message count. |
 | `evals.Result[T]` | `{Resp T, Err error, Latency time.Duration}`. |
+| `evals.ServerStreamResult[T]` | `{Messages []T, Err, TTFB, TotalDuration, MessageIntervals}`. |
+| `evals.ClientStreamResult[Resp]` | `{Resp, Err, SendDuration, ResponseLatency, TotalDuration, MessagesSent}`. |
 | `evals.Rouge1F1(hypothesis, reference string) float64` | Deterministic ROUGE-1 unigram F1 scorer. Empty-empty → 1; one-empty → 0. Feed into `t.Score`. |
 | `evals.DefaultLoadProfile(mode evalspb.RunLoadTestRequest_Mode) (Profile, bool)` | Look up the framework default profile for `mode`. Returns `(zero, false)` for `MODE_UNSPECIFIED`. |
 | `evals.ResolveLoadProfile(mode, overrides map[Mode]Profile) (Profile, bool)` | Merge suite overrides with defaults. Override wins; other modes keep defaults. |
 
 # `Call` and `Result[T]`
 
-`Call` is the idiomatic wrapper for RPC invocation:
+`Call` is the idiomatic wrapper for unary RPC invocation:
 
 ```go
 r := evals.Call(ctx, func(ctx context.Context) (*examplepb.Item, error) {
@@ -41,6 +45,78 @@ type Result[T any] struct {
 
 `Latency` is wall-clock only — the framework does not attempt to
 subtract client-side serialisation.
+
+# Streaming helpers
+
+## When to use
+
+- **Unary `Call`** — single request/response RPCs (and client-streaming when split timing is not needed).
+- **`CallServerStream`** — bounded server-streaming RPCs that terminate with EOF.
+- **`CallClientStream`** — client-streaming RPCs where send-side vs response-side timing matters.
+
+## Server-streaming example
+
+```go
+res := evals.CallServerStream(ctx, func(ctx context.Context) (grpc.ServerStreamingClient[examplepb.Event], error) {
+    return clients.Example.WatchEvents(ctx, req)
+})
+if !t.NoErr("grpc", res.Err) { return }
+if len(res.Messages) > 0 {
+    t.Max("ttfb", res.TTFB, 100*time.Millisecond)
+}
+t.Max("total", res.TotalDuration, 2*time.Second)
+if len(res.MessageIntervals) > 0 {
+    t.Max("gap-0", res.MessageIntervals[0], 500*time.Millisecond)
+}
+```
+
+## Client-streaming example
+
+```go
+r := evals.CallClientStream(ctx,
+    func(ctx context.Context) (grpc.ClientStreamingClient[examplepb.Chunk, examplepb.UploadResult], error) {
+        return clients.Example.Upload(ctx)
+    },
+    func(stream grpc.ClientStreamingClient[examplepb.Chunk, examplepb.UploadResult]) (examplepb.UploadResult, error) {
+        for _, chunk := range chunks {
+            if err := stream.Send(chunk); err != nil {
+                return examplepb.UploadResult{}, err
+            }
+        }
+        resp, err := stream.CloseAndRecv()
+        if err != nil {
+            return examplepb.UploadResult{}, err
+        }
+        return *resp, nil
+    },
+)
+if !t.NoErr("grpc", r.Err) { return }
+t.Max("send", r.SendDuration, 500*time.Millisecond)
+t.Max("response", r.ResponseLatency, 200*time.Millisecond)
+```
+
+## `ServerStreamResult[T]`
+
+| Field | Meaning |
+| ----- | ------- |
+| `Messages` | All successfully received messages (partial on recv error). |
+| `Err` | Transport error; nil on clean EOF. Set on nil-message `Recv`. |
+| `TTFB` | Start through first message; includes `openFn`. **0 when empty — guard before asserting.** |
+| `TotalDuration` | Wall clock from start through recv loop exit. |
+| `MessageIntervals` | `len = max(0, len(Messages)-1)`; gap between consecutive messages. |
+
+**Warning:** Do not use on watch/subscribe RPCs that never send EOF. Bound with a context deadline.
+
+## `ClientStreamResult[Resp]`
+
+| Field | Meaning |
+| ----- | ------- |
+| `Resp` | Final response from `sendFn`. |
+| `Err` | Transport or sendFn error. |
+| `SendDuration` | Start through last successful Send (includes `openFn`). |
+| `ResponseLatency` | `CloseAndRecv` entry through return; **0 if never reached** (e.g. send error). |
+| `TotalDuration` | Wall clock through `sendFn` return; may exceed `SendDuration + ResponseLatency`. |
+| `MessagesSent` | Count of successful Sends. |
 
 # `Rouge1F1`
 
@@ -66,11 +142,14 @@ domain (`0.5` is a reasonable starting point for summarisation).
 # Related
 
 * [T recorder](/concepts/t-recorder.md)
+* [Integration suite](/suites/integration-suite.md)
 * [Agent-eval suite](/suites/agent-eval-suite.md)
 * [Load profile fields](/api/load-profile.md)
 
 # Citations
 
 [1] [call.go](https://github.com/alis-exchange/go-alis-build/blob/main/evals/call.go)
-[2] [score.go](https://github.com/alis-exchange/go-alis-build/blob/main/evals/score.go)
-[3] [load_profile.go](https://github.com/alis-exchange/go-alis-build/blob/main/evals/load_profile.go)
+[2] [stream_server.go](https://github.com/alis-exchange/go-alis-build/blob/main/evals/stream_server.go)
+[3] [stream_client.go](https://github.com/alis-exchange/go-alis-build/blob/main/evals/stream_client.go)
+[4] [score.go](https://github.com/alis-exchange/go-alis-build/blob/main/evals/score.go)
+[5] [load_profile.go](https://github.com/alis-exchange/go-alis-build/blob/main/evals/load_profile.go)

--- a/evals/knowledge/api/index.md
+++ b/evals/knowledge/api/index.md
@@ -15,7 +15,7 @@ grouped by purpose.
 * [T methods](/api/t-methods.md) - the full method vocabulary on `*T`.
 * [SLO constructors](/api/slo-constructors.md) - latency, error-rate, and throughput SLOs.
 * [Load profile](/api/load-profile.md) - `Profile` struct fields and semantics.
-* [Helpers](/api/helpers.md) - `Call`, `Result[T]`, `Rouge1F1`, `DefaultLoadProfile`, `ResolveLoadProfile`.
+* [Helpers](/api/helpers.md) - `Call`, streaming helpers, `Result[T]`, `Rouge1F1`, load-profile resolution.
 
 # Registration and wiring
 

--- a/evals/knowledge/overview.md
+++ b/evals/knowledge/overview.md
@@ -61,6 +61,10 @@ t.Check("has-name", r.Resp.GetName() != "")
 Load cases do not use `T`. Their assertions are declared as
 [SLOs](/api/slo-constructors.md) alongside the `Target` function.
 
+For gRPC streaming RPCs, use [`CallServerStream`](/api/helpers.md#streaming-helpers)
+and [`CallClientStream`](/api/helpers.md#streaming-helpers) instead of
+unary `Call`.
+
 # Why three kinds under one framework
 
 The three kinds share far more than they differ:

--- a/evals/knowledge/packages/evals.md
+++ b/evals/knowledge/packages/evals.md
@@ -15,7 +15,7 @@ directly. It exposes:
 - Suite constructors: `NewIntegrationSuite`, `NewAgentEvalSuite`, `NewLoadSuite`.
 - The `T` recorder and its methods.
 - SLO constructors for load suites.
-- The `Call`/`Result[T]` RPC wrapper.
+- The `Call` / streaming helpers / `Result[T]` RPC wrappers.
 - The `Rouge1F1` deterministic scorer.
 - Registration functions: `RegisterIntegration`, `RegisterEval`,
   `RegisterLoad`, `RegisterAgent`, `DefaultRegistry`.
@@ -31,9 +31,11 @@ directly. It exposes:
 | `slo.go` | `SLO` type and `SLOLatencyP50/P95/P99`, `SLOErrorRate`, `SLOMinQPS`. |
 | `t.go` | `T` and its methods (`Check`, `Checkf`, `NoErr`, `Max`, `Score`). `DuplicateCheckIDName`. |
 | `call.go` | `Call`, `Result[T]`. |
+| `stream_server.go` | `CallServerStream`, `ServerStreamResult[T]`. |
+| `stream_client.go` | `CallClientStream`, `ClientStreamResult[Resp]`. |
 | `score.go` | `Rouge1F1`. |
 | `register.go` | `RegisterIntegration`, `RegisterEval`, `RegisterLoad`, `RegisterAgent`, `DefaultRegistry`. |
-| `suite_test.go`, `load_test.go`, `slo_test.go`, `t_test.go`, `call_test.go`, `example_test.go` | Tests and doc examples. |
+| `suite_test.go`, `load_test.go`, `slo_test.go`, `t_test.go`, `call_test.go`, `stream_test.go`, `example_test.go` | Tests and doc examples. |
 
 # Related
 

--- a/evals/knowledge/suites/integration-suite.md
+++ b/evals/knowledge/suites/integration-suite.md
@@ -101,6 +101,13 @@ headers, tokens, tracing, or any request-scoped values here. The
 framework itself never attaches auth. Different suites can install
 different decorators; see [Context decoration in the README](https://github.com/alis-exchange/go-alis-build/blob/main/evals/README.md#context-and-authentication).
 
+## Streaming RPCs
+
+For server-streaming and client-streaming RPCs, use `CallServerStream`
+and `CallClientStream` instead of unary `Call`. See
+[Helpers — Streaming](/api/helpers.md#streaming-helpers) and the
+[README Streaming RPCs section](https://github.com/alis-exchange/go-alis-build/blob/main/evals/README.md#streaming-rpcs).
+
 # Wire shape
 
 Results appear as [`IntegrationTestResults`](/wire-types/integration-results.md):

--- a/evals/loadgen/errors.go
+++ b/evals/loadgen/errors.go
@@ -1,0 +1,69 @@
+package loadgen
+
+import (
+	"errors"
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ErrInvalidProfile is returned when a [Profile] fails validation.
+type ErrInvalidProfile struct {
+	Field string
+}
+
+func (e ErrInvalidProfile) Error() string {
+	if e.Field == "" {
+		return "loadgen: invalid profile"
+	}
+	return fmt.Sprintf("loadgen: invalid profile field %s", e.Field)
+}
+
+func (e ErrInvalidProfile) Is(target error) bool {
+	var err ErrInvalidProfile
+	if !errors.As(target, &err) {
+		return false
+	}
+	if e.Field == "" || err.Field == "" {
+		return true
+	}
+	return e.Field == err.Field
+}
+
+func (e ErrInvalidProfile) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrNilTarget is returned when Generator.Run is called with a nil target.
+type ErrNilTarget struct{}
+
+func (e ErrNilTarget) Error() string { return "loadgen: nil target" }
+
+func (e ErrNilTarget) Is(target error) bool {
+	var err ErrNilTarget
+	return errors.As(target, &err)
+}
+
+func (e ErrNilTarget) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrTargetPanic is returned when a load target panics during execution.
+type ErrTargetPanic struct {
+	Value any
+	Stack string
+}
+
+func (e ErrTargetPanic) Error() string {
+	return fmt.Sprintf("loadgen: target panic: %v\n%s", e.Value, e.Stack)
+}
+
+func (e ErrTargetPanic) Is(target error) bool {
+	var err ErrTargetPanic
+	return errors.As(target, &err)
+}
+
+func (e ErrTargetPanic) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}

--- a/evals/loadgen/generator.go
+++ b/evals/loadgen/generator.go
@@ -2,7 +2,6 @@ package loadgen
 
 import (
 	"context"
-	"fmt"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -55,7 +54,7 @@ type sample struct {
 // produce a returned error (with partial metrics for ctx cancellation).
 func (g *inProcess) Run(ctx context.Context, p Profile, target Target) (*Metrics, error) {
 	if target == nil {
-		return nil, fmt.Errorf("loadgen: nil target")
+		return nil, ErrNilTarget{}
 	}
 	if err := p.validate(); err != nil {
 		return nil, err
@@ -168,7 +167,7 @@ func invokeTarget(ctx context.Context, target Target) (latency time.Duration, er
 	defer func() {
 		latency = time.Since(start)
 		if v := recover(); v != nil {
-			err = fmt.Errorf("target panic: %v\n%s", v, debug.Stack())
+			err = ErrTargetPanic{Value: v, Stack: string(debug.Stack())}
 		}
 	}()
 	err = target(ctx)

--- a/evals/loadgen/generator_test.go
+++ b/evals/loadgen/generator_test.go
@@ -234,9 +234,8 @@ func TestInProcess_PanicRecovered(t *testing.T) {
 	if m.ErrorCount == 0 {
 		t.Fatal("ErrorCount=0, want panics counted")
 	}
-	// status.Code on a non-status error returns Unknown.
-	if m.ErrorsByCode[codes.Unknown.String()] == 0 {
-		t.Fatalf("expected panics under Unknown: %v", m.ErrorsByCode)
+	if m.ErrorsByCode[codes.Internal.String()] == 0 {
+		t.Fatalf("expected panics under Internal: %v", m.ErrorsByCode)
 	}
 }
 
@@ -250,8 +249,8 @@ func TestInProcess_InvalidProfile(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for zero profile")
 	}
-	if !errors.Is(err, ErrInvalidProfile) {
-		t.Fatalf("err=%v, want wrapped ErrInvalidProfile", err)
+	if !errors.Is(err, ErrInvalidProfile{}) {
+		t.Fatalf("err=%v, want ErrInvalidProfile", err)
 	}
 }
 
@@ -263,6 +262,9 @@ func TestInProcess_NilTarget(t *testing.T) {
 	_, err := g.Run(context.Background(), Profile{QPS: 1, Concurrency: 1, Duration: time.Millisecond}, nil)
 	if err == nil {
 		t.Fatal("expected error for nil target")
+	}
+	if !errors.Is(err, ErrNilTarget{}) {
+		t.Fatalf("err = %v, want ErrNilTarget", err)
 	}
 }
 

--- a/evals/loadgen/profile.go
+++ b/evals/loadgen/profile.go
@@ -1,7 +1,6 @@
 package loadgen
 
 import (
-	"errors"
 	"time"
 )
 
@@ -28,25 +27,21 @@ type Profile struct {
 
 const defaultRequestTimeout = 30 * time.Second
 
-// ErrInvalidProfile is returned by Generator.Run when the profile is not
-// usable.
-var ErrInvalidProfile = errors.New("loadgen: invalid profile")
-
 func (p Profile) validate() error {
 	if p.QPS <= 0 {
-		return &invalidProfileError{field: "QPS", value: p.QPS}
+		return ErrInvalidProfile{Field: "QPS"}
 	}
 	if p.Concurrency < 1 {
-		return &invalidProfileError{field: "Concurrency", value: p.Concurrency}
+		return ErrInvalidProfile{Field: "Concurrency"}
 	}
 	if p.Duration <= 0 {
-		return &invalidProfileError{field: "Duration", value: p.Duration}
+		return ErrInvalidProfile{Field: "Duration"}
 	}
 	if p.Warmup < 0 {
-		return &invalidProfileError{field: "Warmup", value: p.Warmup}
+		return ErrInvalidProfile{Field: "Warmup"}
 	}
 	if p.RequestTimeout < 0 {
-		return &invalidProfileError{field: "RequestTimeout", value: p.RequestTimeout}
+		return ErrInvalidProfile{Field: "RequestTimeout"}
 	}
 	return nil
 }
@@ -58,14 +53,3 @@ func (p Profile) resolvedRequestTimeout() time.Duration {
 	}
 	return p.RequestTimeout
 }
-
-type invalidProfileError struct {
-	field string
-	value any
-}
-
-func (e *invalidProfileError) Error() string {
-	return "loadgen: invalid profile field " + e.field
-}
-
-func (e *invalidProfileError) Unwrap() error { return ErrInvalidProfile }

--- a/evals/loadgen/profile_test.go
+++ b/evals/loadgen/profile_test.go
@@ -31,8 +31,8 @@ func TestProfile_Validate(t *testing.T) {
 				if err == nil {
 					t.Fatal("expected error")
 				}
-				if !errors.Is(err, ErrInvalidProfile) {
-					t.Fatalf("err = %v, want wrapped ErrInvalidProfile", err)
+				if !errors.Is(err, ErrInvalidProfile{}) {
+					t.Fatalf("err = %v, want ErrInvalidProfile", err)
 				}
 				return
 			}

--- a/evals/report/bigquery/bigquery.go
+++ b/evals/report/bigquery/bigquery.go
@@ -2,8 +2,6 @@ package bigquery
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -109,7 +107,7 @@ func New(ctx context.Context, projectID, datasetID, tableID string, opts ...Opti
 	}
 	client, err := bigquery.NewClient(ctx, projectID)
 	if err != nil {
-		return nil, fmt.Errorf("bigquery.NewClient: %w", err)
+		return nil, ErrNewClient{Err: err}
 	}
 	r, err := newFromClient(ctx, client, datasetID, tableID, opts...)
 	if err != nil {
@@ -125,7 +123,7 @@ func New(ctx context.Context, projectID, datasetID, tableID string, opts ...Opti
 // remains responsible for closing the client.
 func NewWithClient(ctx context.Context, client *bigquery.Client, datasetID, tableID string, opts ...Option) (*Reporter, error) {
 	if client == nil {
-		return nil, errors.New("bigquery client is nil")
+		return nil, ErrNilClient{}
 	}
 	_, datasetID, tableID, err := normalizeIDs(client.Project(), datasetID, tableID)
 	if err != nil {
@@ -197,13 +195,13 @@ func normalizeIDs(projectID, datasetID, tableID string) (string, string, string,
 	datasetID = strings.TrimSpace(datasetID)
 	tableID = strings.TrimSpace(tableID)
 	if projectID == "" {
-		return "", "", "", errors.New("bigquery project ID is empty")
+		return "", "", "", ErrEmptyProjectID{}
 	}
 	if datasetID == "" {
-		return "", "", "", errors.New("bigquery dataset ID is empty")
+		return "", "", "", ErrEmptyDatasetID{}
 	}
 	if tableID == "" {
-		return "", "", "", errors.New("bigquery table ID is empty")
+		return "", "", "", ErrEmptyTableID{}
 	}
 	return projectID, datasetID, tableID, nil
 }
@@ -248,7 +246,7 @@ func (r *Reporter) ReportRun(ctx context.Context, run *evalspb.Run) error {
 		msg: run.ProtoReflect(),
 	}
 	if err := r.inserter.Put(ctx, saver); err != nil {
-		return fmt.Errorf("bigquery insert into %s.%s: %w", r.datasetID, r.tableID, err)
+		return ErrInsert{DatasetID: r.datasetID, TableID: r.tableID, Err: err}
 	}
 	return nil
 }

--- a/evals/report/bigquery/errors.go
+++ b/evals/report/bigquery/errors.go
@@ -1,0 +1,107 @@
+package bigquery
+
+import (
+	"errors"
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ErrNewClient wraps a failure to construct a BigQuery client.
+type ErrNewClient struct {
+	Err error
+}
+
+func (e ErrNewClient) Error() string {
+	return fmt.Sprintf("bigquery.NewClient: %v", e.Err)
+}
+
+func (e ErrNewClient) Unwrap() error { return e.Err }
+
+func (e ErrNewClient) Is(target error) bool {
+	var err ErrNewClient
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrNewClient) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrNilClient is returned when NewWithClient is called with a nil client.
+type ErrNilClient struct{}
+
+func (e ErrNilClient) Error() string { return "bigquery client is nil" }
+
+func (e ErrNilClient) Is(target error) bool {
+	var err ErrNilClient
+	return errors.As(target, &err)
+}
+
+func (e ErrNilClient) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrEmptyProjectID is returned when the BigQuery project ID is empty.
+type ErrEmptyProjectID struct{}
+
+func (e ErrEmptyProjectID) Error() string { return "bigquery project ID is empty" }
+
+func (e ErrEmptyProjectID) Is(target error) bool {
+	var err ErrEmptyProjectID
+	return errors.As(target, &err)
+}
+
+func (e ErrEmptyProjectID) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrEmptyDatasetID is returned when the BigQuery dataset ID is empty.
+type ErrEmptyDatasetID struct{}
+
+func (e ErrEmptyDatasetID) Error() string { return "bigquery dataset ID is empty" }
+
+func (e ErrEmptyDatasetID) Is(target error) bool {
+	var err ErrEmptyDatasetID
+	return errors.As(target, &err)
+}
+
+func (e ErrEmptyDatasetID) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrEmptyTableID is returned when the BigQuery table ID is empty.
+type ErrEmptyTableID struct{}
+
+func (e ErrEmptyTableID) Error() string { return "bigquery table ID is empty" }
+
+func (e ErrEmptyTableID) Is(target error) bool {
+	var err ErrEmptyTableID
+	return errors.As(target, &err)
+}
+
+func (e ErrEmptyTableID) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrInsert wraps a failure to insert a row into BigQuery.
+type ErrInsert struct {
+	DatasetID string
+	TableID   string
+	Err       error
+}
+
+func (e ErrInsert) Error() string {
+	return fmt.Sprintf("bigquery insert into %s.%s: %v", e.DatasetID, e.TableID, e.Err)
+}
+
+func (e ErrInsert) Unwrap() error { return e.Err }
+
+func (e ErrInsert) Is(target error) bool {
+	var err ErrInsert
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrInsert) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}

--- a/evals/report/bqschema/errors.go
+++ b/evals/report/bqschema/errors.go
@@ -1,0 +1,111 @@
+package bqschema
+
+import (
+	"errors"
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ErrDatasetNotFound is returned when the target dataset does not exist.
+type ErrDatasetNotFound struct {
+	DatasetID string
+}
+
+func (e ErrDatasetNotFound) Error() string {
+	return fmt.Sprintf("bigquery dataset %q does not exist; create the dataset (e.g. via Terraform or `bq mk`) before starting the reporter", e.DatasetID)
+}
+
+func (e ErrDatasetNotFound) Is(target error) bool {
+	var err ErrDatasetNotFound
+	return errors.As(target, &err)
+}
+
+func (e ErrDatasetNotFound) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, e.Error())
+}
+
+// ErrDatasetMetadata wraps a failure to read dataset metadata.
+type ErrDatasetMetadata struct {
+	DatasetID string
+	Err       error
+}
+
+func (e ErrDatasetMetadata) Error() string {
+	return fmt.Sprintf("bigquery dataset %q metadata: %v", e.DatasetID, e.Err)
+}
+
+func (e ErrDatasetMetadata) Unwrap() error { return e.Err }
+
+func (e ErrDatasetMetadata) Is(target error) bool {
+	var err ErrDatasetMetadata
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrDatasetMetadata) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrTableMetadata wraps a failure to read table metadata.
+type ErrTableMetadata struct {
+	Qualified string
+	Err       error
+}
+
+func (e ErrTableMetadata) Error() string {
+	return fmt.Sprintf("bigquery table %s metadata: %v", e.Qualified, e.Err)
+}
+
+func (e ErrTableMetadata) Unwrap() error { return e.Err }
+
+func (e ErrTableMetadata) Is(target error) bool {
+	var err ErrTableMetadata
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrTableMetadata) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrCreateTable wraps a failure to create a BigQuery table.
+type ErrCreateTable struct {
+	Qualified string
+	Err       error
+}
+
+func (e ErrCreateTable) Error() string {
+	return fmt.Sprintf("create bigquery table %s: %v", e.Qualified, e.Err)
+}
+
+func (e ErrCreateTable) Unwrap() error { return e.Err }
+
+func (e ErrCreateTable) Is(target error) bool {
+	var err ErrCreateTable
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrCreateTable) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrUpdateTableSchema wraps a failure to additively update a table schema.
+type ErrUpdateTableSchema struct {
+	Qualified string
+	Err       error
+}
+
+func (e ErrUpdateTableSchema) Error() string {
+	return fmt.Sprintf("update bigquery table %s schema (additive changes only): %v", e.Qualified, e.Err)
+}
+
+func (e ErrUpdateTableSchema) Unwrap() error { return e.Err }
+
+func (e ErrUpdateTableSchema) Is(target error) bool {
+	var err ErrUpdateTableSchema
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrUpdateTableSchema) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}

--- a/evals/report/bqschema/provisioner.go
+++ b/evals/report/bqschema/provisioner.go
@@ -61,15 +61,15 @@ func ensureTableWith(ctx context.Context, prov tableProvisioner, datasetID, tabl
 
 	if err := prov.datasetMetadata(ctx); err != nil {
 		if isNotFound(err) {
-			return fmt.Errorf("bigquery dataset %q does not exist; create the dataset (e.g. via Terraform or `bq mk`) before starting the reporter", datasetID)
+			return ErrDatasetNotFound{DatasetID: datasetID}
 		}
-		return fmt.Errorf("bigquery dataset %q metadata: %w", datasetID, err)
+		return ErrDatasetMetadata{DatasetID: datasetID, Err: err}
 	}
 
 	meta, err := prov.tableMetadata(ctx)
 	if err != nil {
 		if !isNotFound(err) {
-			return fmt.Errorf("bigquery table %s metadata: %w", qualified, err)
+			return ErrTableMetadata{Qualified: qualified, Err: err}
 		}
 		create := &bigquery.TableMetadata{}
 		if tableMD != nil {
@@ -77,14 +77,14 @@ func ensureTableWith(ctx context.Context, prov tableProvisioner, datasetID, tabl
 		}
 		create.Schema = schema
 		if err := prov.createTable(ctx, create); err != nil {
-			return fmt.Errorf("create bigquery table %s: %w", qualified, err)
+			return ErrCreateTable{Qualified: qualified, Err: err}
 		}
 		alog.Infof(ctx, "bqschema: created table %s", qualified)
 		return nil
 	}
 
 	if err := prov.updateSchemaAdditive(ctx, schema, meta.ETag); err != nil {
-		return fmt.Errorf("update bigquery table %s schema (additive changes only): %w", qualified, err)
+		return ErrUpdateTableSchema{Qualified: qualified, Err: err}
 	}
 	alog.Debugf(ctx, "bqschema: ensured schema for table %s", qualified)
 	return nil

--- a/evals/report/pubsub/errors.go
+++ b/evals/report/pubsub/errors.go
@@ -1,0 +1,119 @@
+package pubsub
+
+import (
+	"errors"
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ErrEmptyProjectID is returned when New cannot resolve a Google Cloud project ID.
+type ErrEmptyProjectID struct {
+	EnvVar string
+}
+
+func (e ErrEmptyProjectID) Error() string {
+	return fmt.Sprintf("pubsub reporter: project ID is empty (set %s or pass WithProject)", e.EnvVar)
+}
+
+func (e ErrEmptyProjectID) Is(target error) bool {
+	var err ErrEmptyProjectID
+	return errors.As(target, &err)
+}
+
+func (e ErrEmptyProjectID) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrNewClient wraps a failure to construct a Pub/Sub client.
+type ErrNewClient struct {
+	Err error
+}
+
+func (e ErrNewClient) Error() string {
+	return fmt.Sprintf("pubsub.NewClient: %v", e.Err)
+}
+
+func (e ErrNewClient) Unwrap() error { return e.Err }
+
+func (e ErrNewClient) Is(target error) bool {
+	var err ErrNewClient
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrNewClient) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrNilClient is returned when NewWithClient is called with a nil client.
+type ErrNilClient struct{}
+
+func (e ErrNilClient) Error() string { return "pubsub client is nil" }
+
+func (e ErrNilClient) Is(target error) bool {
+	var err ErrNilClient
+	return errors.As(target, &err)
+}
+
+func (e ErrNilClient) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrWithProjectWithClient is returned when WithProject is passed to NewWithClient.
+type ErrWithProjectWithClient struct{}
+
+func (e ErrWithProjectWithClient) Error() string {
+	return "pubsub reporter: WithProject is not valid with NewWithClient (the client already has a project)"
+}
+
+func (e ErrWithProjectWithClient) Is(target error) bool {
+	var err ErrWithProjectWithClient
+	return errors.As(target, &err)
+}
+
+func (e ErrWithProjectWithClient) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrPublishMarshal wraps a failure to marshal a run for Pub/Sub publish.
+type ErrPublishMarshal struct {
+	Topic string
+	Err   error
+}
+
+func (e ErrPublishMarshal) Error() string {
+	return fmt.Sprintf("pubsub publish %s: protojson marshal: %v", e.Topic, e.Err)
+}
+
+func (e ErrPublishMarshal) Unwrap() error { return e.Err }
+
+func (e ErrPublishMarshal) Is(target error) bool {
+	var err ErrPublishMarshal
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrPublishMarshal) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrPublish wraps a failure to publish a message to Pub/Sub.
+type ErrPublish struct {
+	Topic string
+	Err   error
+}
+
+func (e ErrPublish) Error() string {
+	return fmt.Sprintf("pubsub publish %s: %v", e.Topic, e.Err)
+}
+
+func (e ErrPublish) Unwrap() error { return e.Err }
+
+func (e ErrPublish) Is(target error) bool {
+	var err ErrPublish
+	return errors.As(target, &err) || errors.Is(e.Err, target)
+}
+
+func (e ErrPublish) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}

--- a/evals/report/pubsub/pubsub.go
+++ b/evals/report/pubsub/pubsub.go
@@ -2,8 +2,6 @@ package pubsub
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"os"
 	"time"
 
@@ -165,11 +163,11 @@ func New(ctx context.Context, opts ...Option) (*Reporter, error) {
 		projectID = os.Getenv(projectEnvVar)
 	}
 	if projectID == "" {
-		return nil, fmt.Errorf("pubsub reporter: project ID is empty (set %s or pass WithProject)", projectEnvVar)
+		return nil, ErrEmptyProjectID{EnvVar: projectEnvVar}
 	}
 	client, err := newPubsubClient(ctx, projectID)
 	if err != nil {
-		return nil, fmt.Errorf("pubsub.NewClient: %w", err)
+		return nil, ErrNewClient{Err: err}
 	}
 	r, err := newFromClient(client, cfg)
 	if err != nil {
@@ -189,11 +187,11 @@ func New(ctx context.Context, opts ...Option) (*Reporter, error) {
 // to it. Passing WithProject returns an error at construction.
 func NewWithClient(client *pubsub.Client, opts ...Option) (*Reporter, error) {
 	if client == nil {
-		return nil, errors.New("pubsub client is nil")
+		return nil, ErrNilClient{}
 	}
 	cfg := loadConfig(opts)
 	if cfg.project != "" {
-		return nil, errors.New("pubsub reporter: WithProject is not valid with NewWithClient (the client already has a project)")
+		return nil, ErrWithProjectWithClient{}
 	}
 	return newFromClient(client, cfg)
 }
@@ -282,7 +280,7 @@ func (r *Reporter) ReportRun(ctx context.Context, run *evalspb.Run) error {
 	defer cancel()
 	data, err := marshalOptions.Marshal(run)
 	if err != nil {
-		return fmt.Errorf("pubsub publish %s: protojson marshal: %w", r.topic, err)
+		return ErrPublishMarshal{Topic: r.topic, Err: err}
 	}
 	msg := &pubsub.Message{Data: data}
 	if r.orderingKey != "" {
@@ -293,7 +291,7 @@ func (r *Reporter) ReportRun(ctx context.Context, run *evalspb.Run) error {
 		return nil
 	}
 	if _, err := result.Get(ctx); err != nil {
-		return fmt.Errorf("pubsub publish %s: %w", r.topic, err)
+		return ErrPublish{Topic: r.topic, Err: err}
 	}
 	return nil
 }

--- a/evals/runner/errors.go
+++ b/evals/runner/errors.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"errors"
+	"fmt"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -32,5 +33,41 @@ func (e ErrNilResult) Is(target error) bool {
 }
 
 func (e ErrNilResult) GRPCStatus() *status.Status {
+	return status.New(codes.Internal, e.Error())
+}
+
+// ErrNilLoadProfileResolver is returned when RunLoadSuites is called with a
+// nil load profile resolver.
+type ErrNilLoadProfileResolver struct{}
+
+func (e ErrNilLoadProfileResolver) Error() string {
+	return "runner: nil load profile resolver"
+}
+
+func (e ErrNilLoadProfileResolver) Is(target error) bool {
+	var err ErrNilLoadProfileResolver
+	return errors.As(target, &err)
+}
+
+func (e ErrNilLoadProfileResolver) GRPCStatus() *status.Status {
+	return status.New(codes.InvalidArgument, e.Error())
+}
+
+// ErrCasePanic is returned when a case panics during execution.
+type ErrCasePanic struct {
+	Value any
+	Stack string
+}
+
+func (e ErrCasePanic) Error() string {
+	return fmt.Sprintf("panic: %v\n%s", e.Value, e.Stack)
+}
+
+func (e ErrCasePanic) Is(target error) bool {
+	var err ErrCasePanic
+	return errors.As(target, &err)
+}
+
+func (e ErrCasePanic) GRPCStatus() *status.Status {
 	return status.New(codes.Internal, e.Error())
 }

--- a/evals/runner/runner.go
+++ b/evals/runner/runner.go
@@ -299,7 +299,7 @@ func (r *Runner) RunLoadSuites(
 		return nil, err
 	}
 	if resolve == nil {
-		return nil, fmt.Errorf("runner: nil load profile resolver")
+		return nil, ErrNilLoadProfileResolver{}
 	}
 
 	envTeardown, err := setupEnvironments(r.baseCtx(ctx), collectLoadEnvironmentNames(runs))
@@ -399,13 +399,14 @@ func (r *Runner) RunLoadSuites(
 func runLoadCaseWithRecovery(ctx context.Context, c suite.LoadCase, mode evalspb.RunLoadTestRequest_Mode, profile loadgen.Profile) (r *execution.LoadCaseResult) {
 	defer func() {
 		if v := recover(); v != nil {
+			panicErr := ErrCasePanic{Value: v, Stack: string(debug.Stack())}
 			r = &execution.LoadCaseResult{
 				Name:   c.Name(),
 				Status: evalspb.Status_FAILED,
 				Checks: []execution.SloCheckResult{{
 					ID:      result.CaseErrorCheckName,
 					Status:  evalspb.Status_FAILED,
-					Message: fmt.Sprintf("panic: %v\n%s", v, debug.Stack()),
+					Message: panicErr.Error(),
 				}},
 			}
 		}
@@ -418,7 +419,7 @@ func runLoadCaseWithRecovery(ctx context.Context, c suite.LoadCase, mode evalspb
 func runTestCaseWithRecovery(ctx context.Context, c suite.TestCase) (r *execution.CaseResult) {
 	defer func() {
 		if v := recover(); v != nil {
-			r = result.CaseErrorResult(c.Name(), fmt.Errorf("panic: %v\n%s", v, debug.Stack()))
+			r = result.CaseErrorResult(c.Name(), ErrCasePanic{Value: v, Stack: string(debug.Stack())})
 		}
 	}()
 	return c.Run(ctx)
@@ -429,7 +430,7 @@ func runTestCaseWithRecovery(ctx context.Context, c suite.TestCase) (r *executio
 func runEvalCaseWithRecovery(ctx context.Context, c suite.EvalCase) (r *execution.CaseResult) {
 	defer func() {
 		if v := recover(); v != nil {
-			r = result.EvalCaseErrorResult(c.Name(), fmt.Errorf("panic: %v\n%s", v, debug.Stack()))
+			r = result.EvalCaseErrorResult(c.Name(), ErrCasePanic{Value: v, Stack: string(debug.Stack())})
 		}
 	}()
 	return c.Run(ctx)

--- a/evals/stream_client.go
+++ b/evals/stream_client.go
@@ -107,6 +107,12 @@ func CallClientStream[Req, Resp any](
 			TotalDuration: time.Since(start),
 		}
 	}
+	if stream == nil {
+		return ClientStreamResult[Resp]{
+			Err:           ErrNilStream{},
+			TotalDuration: time.Since(start),
+		}
+	}
 
 	wrapped := &instrumentedClientStream[Req, Resp]{
 		ClientStreamingClient: stream,

--- a/evals/stream_client.go
+++ b/evals/stream_client.go
@@ -1,0 +1,125 @@
+package evals
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// ClientStreamResult is what CallClientStream returns: the typed response,
+// transport error (if any), and send/response timing captured by the framework.
+//
+// SendDuration includes stream open through the last successful Send (or through
+// the first send error, or CloseAndRecv entry when no sends occurred). It is
+// not send-only wall time — openFn cost is included, consistent with server
+// streaming TTFB.
+//
+// ResponseLatency spans CloseAndRecv entry through return. It is 0 when
+// CloseAndRecv was never reached.
+//
+// TotalDuration is wall clock from call start through sendFn return.
+// TotalDuration may exceed SendDuration + ResponseLatency because the gap
+// between the last Send return and CloseAndRecv entry is author overhead.
+type ClientStreamResult[Resp any] struct {
+	Resp            Resp
+	Err             error
+	SendDuration    time.Duration
+	ResponseLatency time.Duration
+	TotalDuration   time.Duration
+	MessagesSent    int
+}
+
+type clientStreamTiming struct {
+	start             time.Time
+	messagesSent      int
+	lastSendEnd       time.Time
+	sendFailedAt      time.Time
+	closeAndRecvStart time.Time
+	closeAndRecvEnd   time.Time
+	closeInvoked      bool
+	sendFailed        bool
+	hadSuccessfulSend bool
+}
+
+type instrumentedClientStream[Req, Resp any] struct {
+	grpc.ClientStreamingClient[Req, Resp]
+	timing *clientStreamTiming
+}
+
+func (w *instrumentedClientStream[Req, Resp]) Send(req *Req) error {
+	err := w.ClientStreamingClient.Send(req)
+	now := time.Now()
+	if err != nil {
+		w.timing.sendFailed = true
+		w.timing.sendFailedAt = now
+		return err
+	}
+	w.timing.messagesSent++
+	w.timing.hadSuccessfulSend = true
+	w.timing.lastSendEnd = now
+	return nil
+}
+
+func (w *instrumentedClientStream[Req, Resp]) CloseAndRecv() (*Resp, error) {
+	w.timing.closeInvoked = true
+	w.timing.closeAndRecvStart = time.Now()
+	resp, err := w.ClientStreamingClient.CloseAndRecv()
+	w.timing.closeAndRecvEnd = time.Now()
+	return resp, err
+}
+
+func sendDuration(t *clientStreamTiming) time.Duration {
+	switch {
+	case t.hadSuccessfulSend:
+		return t.lastSendEnd.Sub(t.start)
+	case t.sendFailed:
+		return t.sendFailedAt.Sub(t.start)
+	case t.closeInvoked:
+		return t.closeAndRecvStart.Sub(t.start)
+	default:
+		return time.Since(t.start)
+	}
+}
+
+func responseLatency(t *clientStreamTiming) time.Duration {
+	if !t.closeInvoked {
+		return 0
+	}
+	return t.closeAndRecvEnd.Sub(t.closeAndRecvStart)
+}
+
+// CallClientStream opens a client-streaming RPC, invokes sendFn with an
+// instrumented stream that counts sends and records send vs response timing,
+// and returns the aggregated result. Assertions are the author's responsibility.
+func CallClientStream[Req, Resp any](
+	ctx context.Context,
+	openFn func(context.Context) (grpc.ClientStreamingClient[Req, Resp], error),
+	sendFn func(grpc.ClientStreamingClient[Req, Resp]) (Resp, error),
+) ClientStreamResult[Resp] {
+	start := time.Now()
+	timing := &clientStreamTiming{start: start}
+
+	stream, err := openFn(ctx)
+	if err != nil {
+		return ClientStreamResult[Resp]{
+			Err:           err,
+			TotalDuration: time.Since(start),
+		}
+	}
+
+	wrapped := &instrumentedClientStream[Req, Resp]{
+		ClientStreamingClient: stream,
+		timing:                timing,
+	}
+	resp, err := sendFn(wrapped)
+
+	return ClientStreamResult[Resp]{
+		Resp:            resp,
+		Err:             err,
+		SendDuration:    sendDuration(timing),
+		ResponseLatency: responseLatency(timing),
+		TotalDuration:   time.Since(start),
+		MessagesSent:    timing.messagesSent,
+	}
+}

--- a/evals/stream_server.go
+++ b/evals/stream_server.go
@@ -2,14 +2,11 @@ package evals
 
 import (
 	"context"
-	"errors"
 	"io"
 	"time"
 
 	"google.golang.org/grpc"
 )
-
-var errNilStreamMessage = errors.New("evals: server stream Recv returned nil message")
 
 // ServerStreamResult is what CallServerStream returns: drained messages,
 // transport error (if any), and timing captured uniformly by the framework.
@@ -46,6 +43,12 @@ func CallServerStream[T any](
 			TotalDuration: time.Since(start),
 		}
 	}
+	if stream == nil {
+		return ServerStreamResult[T]{
+			Err:           ErrNilStream{},
+			TotalDuration: time.Since(start),
+		}
+	}
 
 	var (
 		messages  []T
@@ -73,7 +76,7 @@ func CallServerStream[T any](
 		if msg == nil {
 			return ServerStreamResult[T]{
 				Messages:         messages,
-				Err:              errNilStreamMessage,
+				Err:              ErrNilStreamMessage{},
 				TTFB:             ttfb,
 				TotalDuration:    time.Since(start),
 				MessageIntervals: intervals,

--- a/evals/stream_server.go
+++ b/evals/stream_server.go
@@ -1,0 +1,98 @@
+package evals
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+var errNilStreamMessage = errors.New("evals: server stream Recv returned nil message")
+
+// ServerStreamResult is what CallServerStream returns: drained messages,
+// transport error (if any), and timing captured uniformly by the framework.
+type ServerStreamResult[T any] struct {
+	Messages         []T
+	Err              error
+	TTFB             time.Duration
+	TotalDuration    time.Duration
+	MessageIntervals []time.Duration
+}
+
+// CallServerStream opens a server-streaming RPC, drains messages until EOF or
+// error, and captures timing. TTFB is the elapsed time from call start
+// (including openFn) through the first successful Recv; it is 0 when no
+// message is received — guard with len(Messages) > 0 before asserting on TTFB.
+//
+// MessageIntervals[i] is the elapsed time between Messages[i] and Messages[i+1].
+// Length is max(0, len(Messages)-1).
+//
+// If Recv returns a nil message with nil error, Err is set and partial
+// messages received so far are preserved.
+//
+// Do not use on watch/subscribe RPCs that never send EOF — the call blocks
+// until context cancellation. Use a context deadline to bound execution.
+func CallServerStream[T any](
+	ctx context.Context,
+	openFn func(context.Context) (grpc.ServerStreamingClient[T], error),
+) ServerStreamResult[T] {
+	start := time.Now()
+	stream, err := openFn(ctx)
+	if err != nil {
+		return ServerStreamResult[T]{
+			Err:           err,
+			TotalDuration: time.Since(start),
+		}
+	}
+
+	var (
+		messages  []T
+		intervals []time.Duration
+		ttfb      time.Duration
+		lastRecv  time.Time
+		gotFirst  bool
+	)
+
+	for {
+		msg, err := stream.Recv()
+		now := time.Now()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return ServerStreamResult[T]{
+				Messages:         messages,
+				Err:              err,
+				TTFB:             ttfb,
+				TotalDuration:    time.Since(start),
+				MessageIntervals: intervals,
+			}
+		}
+		if msg == nil {
+			return ServerStreamResult[T]{
+				Messages:         messages,
+				Err:              errNilStreamMessage,
+				TTFB:             ttfb,
+				TotalDuration:    time.Since(start),
+				MessageIntervals: intervals,
+			}
+		}
+		if !gotFirst {
+			ttfb = now.Sub(start)
+			gotFirst = true
+		} else {
+			intervals = append(intervals, now.Sub(lastRecv))
+		}
+		lastRecv = now
+		messages = append(messages, *msg)
+	}
+
+	return ServerStreamResult[T]{
+		Messages:         messages,
+		TTFB:             ttfb,
+		TotalDuration:    time.Since(start),
+		MessageIntervals: intervals,
+	}
+}

--- a/evals/stream_test.go
+++ b/evals/stream_test.go
@@ -1,0 +1,426 @@
+package evals
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+type fakeClientStream struct {
+	ctx context.Context
+}
+
+func (f *fakeClientStream) Header() (metadata.MD, error) { return nil, nil }
+func (f *fakeClientStream) Trailer() metadata.MD         { return nil }
+func (f *fakeClientStream) CloseSend() error             { return nil }
+func (f *fakeClientStream) Context() context.Context {
+	if f.ctx != nil {
+		return f.ctx
+	}
+	return context.Background()
+}
+func (f *fakeClientStream) SendMsg(any) error { return nil }
+func (f *fakeClientStream) RecvMsg(any) error { return nil }
+
+type fakeServerStream[T any] struct {
+	fakeClientStream
+	msgs    []T
+	delays  []time.Duration
+	idx     int
+	recvErr error
+}
+
+func (s *fakeServerStream[T]) Recv() (*T, error) {
+	if err := s.Context().Err(); err != nil {
+		return nil, err
+	}
+	if s.idx < len(s.delays) {
+		time.Sleep(s.delays[s.idx])
+	}
+	if s.idx >= len(s.msgs) {
+		if s.recvErr != nil {
+			return nil, s.recvErr
+		}
+		return nil, io.EOF
+	}
+	msg := s.msgs[s.idx]
+	s.idx++
+	return &msg, nil
+}
+
+func TestCallServerStream_threeMessages(t *testing.T) {
+	t.Parallel()
+	const (
+		d0 = 8 * time.Millisecond
+		d1 = 12 * time.Millisecond
+		d2 = 6 * time.Millisecond
+	)
+	stream := &fakeServerStream[int]{
+		msgs:   []int{1, 2, 3},
+		delays: []time.Duration{d0, d1, d2},
+	}
+	got := CallServerStream(context.Background(), func(context.Context) (grpc.ServerStreamingClient[int], error) {
+		return stream, nil
+	})
+	if got.Err != nil {
+		t.Fatalf("Err = %v, want nil", got.Err)
+	}
+	if len(got.Messages) != 3 {
+		t.Fatalf("len(Messages) = %d, want 3", len(got.Messages))
+	}
+	if len(got.MessageIntervals) != 2 {
+		t.Fatalf("len(MessageIntervals) = %d, want 2", len(got.MessageIntervals))
+	}
+	assertDurationAround(t, "TTFB", got.TTFB, d0, 4*time.Millisecond)
+	assertDurationAround(t, "interval[0]", got.MessageIntervals[0], d1, 4*time.Millisecond)
+	assertDurationAround(t, "interval[1]", got.MessageIntervals[1], d2, 4*time.Millisecond)
+	minTotal := d0 + d1 + d2
+	if got.TotalDuration < minTotal {
+		t.Fatalf("TotalDuration = %v, want >= %v", got.TotalDuration, minTotal)
+	}
+}
+
+func TestCallServerStream_zeroMessagesEOF(t *testing.T) {
+	t.Parallel()
+	stream := &fakeServerStream[int]{}
+	got := CallServerStream(context.Background(), func(context.Context) (grpc.ServerStreamingClient[int], error) {
+		return stream, nil
+	})
+	if got.Err != nil {
+		t.Fatalf("Err = %v, want nil", got.Err)
+	}
+	if len(got.Messages) != 0 {
+		t.Fatalf("Messages = %v, want empty", got.Messages)
+	}
+	if got.TTFB != 0 {
+		t.Fatalf("TTFB = %v, want 0", got.TTFB)
+	}
+	if len(got.MessageIntervals) != 0 {
+		t.Fatalf("MessageIntervals = %v, want empty", got.MessageIntervals)
+	}
+}
+
+func TestCallServerStream_recvErrorAfterTwo(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("recv failed")
+	stream := &fakeServerStream[int]{
+		msgs:    []int{1, 2},
+		recvErr: wantErr,
+	}
+	got := CallServerStream(context.Background(), func(context.Context) (grpc.ServerStreamingClient[int], error) {
+		return stream, nil
+	})
+	if !errors.Is(got.Err, wantErr) {
+		t.Fatalf("Err = %v, want %v", got.Err, wantErr)
+	}
+	if len(got.Messages) != 2 {
+		t.Fatalf("len(Messages) = %d, want 2", len(got.Messages))
+	}
+	if len(got.MessageIntervals) != 1 {
+		t.Fatalf("len(MessageIntervals) = %d, want 1", len(got.MessageIntervals))
+	}
+	if got.TotalDuration < 0 {
+		t.Fatalf("TotalDuration = %v, want non-negative", got.TotalDuration)
+	}
+}
+
+func TestCallServerStream_openFnError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("open failed")
+	got := CallServerStream(context.Background(), func(context.Context) (grpc.ServerStreamingClient[int], error) {
+		return nil, wantErr
+	})
+	if !errors.Is(got.Err, wantErr) {
+		t.Fatalf("Err = %v, want %v", got.Err, wantErr)
+	}
+	if len(got.Messages) != 0 {
+		t.Fatalf("Messages = %v, want empty", got.Messages)
+	}
+	if got.TTFB != 0 {
+		t.Fatalf("TTFB = %v, want 0", got.TTFB)
+	}
+	if got.TotalDuration < 0 {
+		t.Fatalf("TotalDuration = %v, want non-negative", got.TotalDuration)
+	}
+}
+
+func TestCallServerStream_nilMessage(t *testing.T) {
+	t.Parallel()
+	got := CallServerStream(context.Background(), func(context.Context) (grpc.ServerStreamingClient[int], error) {
+		return &nilMessageServerStream{}, nil
+	})
+	if !errors.Is(got.Err, errNilStreamMessage) {
+		t.Fatalf("Err = %v, want %v", got.Err, errNilStreamMessage)
+	}
+	if len(got.Messages) != 0 {
+		t.Fatalf("Messages = %v, want empty", got.Messages)
+	}
+}
+
+type nilMessageServerStream struct {
+	fakeClientStream
+}
+
+func (s *nilMessageServerStream) Recv() (*int, error) {
+	return nil, nil
+}
+
+func TestCallServerStream_contextCanceled(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	got := CallServerStream(ctx, func(c context.Context) (grpc.ServerStreamingClient[int], error) {
+		return &fakeServerStream[int]{
+			fakeClientStream: fakeClientStream{ctx: c},
+			msgs:             []int{1},
+			delays:           []time.Duration{50 * time.Millisecond},
+		}, nil
+	})
+	if got.Err == nil {
+		t.Fatal("Err = nil, want context error")
+	}
+}
+
+func assertDurationAround(t *testing.T, name string, got, want, slack time.Duration) {
+	t.Helper()
+	if got < want-slack || got > want+slack {
+		t.Fatalf("%s = %v, want around %v (+/- %v)", name, got, want, slack)
+	}
+}
+
+type fakeClientStreamSend[Req, Resp any] struct {
+	fakeClientStream
+	sendDelay    time.Duration
+	closeDelay   time.Duration
+	failOnSend   int // 1-based; 0 = never
+	msgsSent     int
+	closeAndRecv func() (*Resp, error)
+}
+
+func (s *fakeClientStreamSend[Req, Resp]) Send(*Req) error {
+	s.msgsSent++
+	if s.failOnSend > 0 && s.msgsSent == s.failOnSend {
+		return errors.New("send failed")
+	}
+	if s.sendDelay > 0 {
+		time.Sleep(s.sendDelay)
+	}
+	return nil
+}
+
+func (s *fakeClientStreamSend[Req, Resp]) CloseAndRecv() (*Resp, error) {
+	if s.closeDelay > 0 {
+		time.Sleep(s.closeDelay)
+	}
+	if s.closeAndRecv != nil {
+		return s.closeAndRecv()
+	}
+	var zero Resp
+	return &zero, nil
+}
+
+func TestCallClientStream_happyPath(t *testing.T) {
+	t.Parallel()
+	const (
+		sendDelay  = 5 * time.Millisecond
+		closeDelay = 8 * time.Millisecond
+	)
+	underlying := &fakeClientStreamSend[int, string]{
+		sendDelay:  sendDelay,
+		closeDelay: closeDelay,
+	}
+	got := CallClientStream(context.Background(),
+		func(context.Context) (grpc.ClientStreamingClient[int, string], error) {
+			return underlying, nil
+		},
+		func(stream grpc.ClientStreamingClient[int, string]) (string, error) {
+			for i := range 3 {
+				if err := stream.Send(&i); err != nil {
+					return "", err
+				}
+			}
+			resp, err := stream.CloseAndRecv()
+			if err != nil {
+				return "", err
+			}
+			return *resp, nil
+		},
+	)
+	if got.Err != nil {
+		t.Fatalf("Err = %v, want nil", got.Err)
+	}
+	if got.MessagesSent != 3 {
+		t.Fatalf("MessagesSent = %d, want 3", got.MessagesSent)
+	}
+	if got.ResponseLatency <= 0 {
+		t.Fatalf("ResponseLatency = %v, want positive", got.ResponseLatency)
+	}
+	if got.SendDuration <= 0 {
+		t.Fatalf("SendDuration = %v, want positive", got.SendDuration)
+	}
+	if got.TotalDuration < got.SendDuration+got.ResponseLatency {
+		t.Fatalf("TotalDuration = %v, want >= SendDuration(%v) + ResponseLatency(%v)",
+			got.TotalDuration, got.SendDuration, got.ResponseLatency)
+	}
+	assertDurationAround(t, "ResponseLatency", got.ResponseLatency, closeDelay, 4*time.Millisecond)
+}
+
+func TestCallClientStream_sendErrorMidWay(t *testing.T) {
+	t.Parallel()
+	underlying := &fakeClientStreamSend[int, string]{
+		failOnSend: 2,
+	}
+	got := CallClientStream(context.Background(),
+		func(context.Context) (grpc.ClientStreamingClient[int, string], error) {
+			return underlying, nil
+		},
+		func(stream grpc.ClientStreamingClient[int, string]) (string, error) {
+			for i := range 3 {
+				if err := stream.Send(&i); err != nil {
+					return "", err
+				}
+			}
+			resp, err := stream.CloseAndRecv()
+			if err != nil {
+				return "", err
+			}
+			return *resp, nil
+		},
+	)
+	if got.Err == nil {
+		t.Fatal("Err = nil, want send error")
+	}
+	if got.MessagesSent != 1 {
+		t.Fatalf("MessagesSent = %d, want 1", got.MessagesSent)
+	}
+	if got.ResponseLatency != 0 {
+		t.Fatalf("ResponseLatency = %v, want 0", got.ResponseLatency)
+	}
+	if got.SendDuration <= 0 {
+		t.Fatalf("SendDuration = %v, want positive", got.SendDuration)
+	}
+}
+
+func TestCallClientStream_firstSendFails(t *testing.T) {
+	t.Parallel()
+	underlying := &fakeClientStreamSend[int, string]{
+		failOnSend: 1,
+	}
+	got := CallClientStream(context.Background(),
+		func(context.Context) (grpc.ClientStreamingClient[int, string], error) {
+			return underlying, nil
+		},
+		func(stream grpc.ClientStreamingClient[int, string]) (string, error) {
+			i := 0
+			if err := stream.Send(&i); err != nil {
+				return "", err
+			}
+			return "", errors.New("unreachable")
+		},
+	)
+	if got.Err == nil {
+		t.Fatal("Err = nil, want send error")
+	}
+	if got.MessagesSent != 0 {
+		t.Fatalf("MessagesSent = %d, want 0", got.MessagesSent)
+	}
+	if got.ResponseLatency != 0 {
+		t.Fatalf("ResponseLatency = %v, want 0", got.ResponseLatency)
+	}
+	if got.SendDuration <= 0 {
+		t.Fatalf("SendDuration = %v, want positive", got.SendDuration)
+	}
+}
+
+func TestCallClientStream_sendFnEarlyReturn(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("validation failed")
+	got := CallClientStream(context.Background(),
+		func(context.Context) (grpc.ClientStreamingClient[int, string], error) {
+			return &fakeClientStreamSend[int, string]{}, nil
+		},
+		func(grpc.ClientStreamingClient[int, string]) (string, error) {
+			return "", wantErr
+		},
+	)
+	if !errors.Is(got.Err, wantErr) {
+		t.Fatalf("Err = %v, want %v", got.Err, wantErr)
+	}
+	if got.MessagesSent != 0 {
+		t.Fatalf("MessagesSent = %d, want 0", got.MessagesSent)
+	}
+	if got.ResponseLatency != 0 {
+		t.Fatalf("ResponseLatency = %v, want 0", got.ResponseLatency)
+	}
+	if got.SendDuration <= 0 {
+		t.Fatalf("SendDuration = %v, want positive", got.SendDuration)
+	}
+	if got.SendDuration > got.TotalDuration {
+		t.Fatalf("SendDuration = %v, want <= TotalDuration %v", got.SendDuration, got.TotalDuration)
+	}
+}
+
+func TestCallClientStream_zeroSendCloseAndRecv(t *testing.T) {
+	t.Parallel()
+	const closeDelay = 6 * time.Millisecond
+	underlying := &fakeClientStreamSend[int, string]{
+		closeDelay: closeDelay,
+	}
+	got := CallClientStream(context.Background(),
+		func(context.Context) (grpc.ClientStreamingClient[int, string], error) {
+			return underlying, nil
+		},
+		func(stream grpc.ClientStreamingClient[int, string]) (string, error) {
+			resp, err := stream.CloseAndRecv()
+			if err != nil {
+				return "", err
+			}
+			return *resp, nil
+		},
+	)
+	if got.Err != nil {
+		t.Fatalf("Err = %v, want nil", got.Err)
+	}
+	if got.MessagesSent != 0 {
+		t.Fatalf("MessagesSent = %d, want 0", got.MessagesSent)
+	}
+	if got.SendDuration <= 0 {
+		t.Fatalf("SendDuration = %v, want positive", got.SendDuration)
+	}
+	if got.ResponseLatency <= 0 {
+		t.Fatalf("ResponseLatency = %v, want positive", got.ResponseLatency)
+	}
+	if got.TotalDuration < got.SendDuration+got.ResponseLatency {
+		t.Fatalf("TotalDuration = %v, want >= SendDuration(%v) + ResponseLatency(%v)",
+			got.TotalDuration, got.SendDuration, got.ResponseLatency)
+	}
+}
+
+func TestCallClientStream_openFnError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("open failed")
+	got := CallClientStream(context.Background(),
+		func(context.Context) (grpc.ClientStreamingClient[int, string], error) {
+			return nil, wantErr
+		},
+		func(grpc.ClientStreamingClient[int, string]) (string, error) {
+			t.Fatal("sendFn should not run")
+			return "", nil
+		},
+	)
+	if !errors.Is(got.Err, wantErr) {
+		t.Fatalf("Err = %v, want %v", got.Err, wantErr)
+	}
+	if got.TotalDuration < 0 {
+		t.Fatalf("TotalDuration = %v, want non-negative", got.TotalDuration)
+	}
+	if got.SendDuration != 0 || got.ResponseLatency != 0 || got.MessagesSent != 0 {
+		t.Fatalf("unexpected timings: SendDuration=%v ResponseLatency=%v MessagesSent=%d",
+			got.SendDuration, got.ResponseLatency, got.MessagesSent)
+	}
+}

--- a/evals/stream_test.go
+++ b/evals/stream_test.go
@@ -149,13 +149,32 @@ func TestCallServerStream_openFnError(t *testing.T) {
 	}
 }
 
+func TestCallServerStream_openFnNilStream(t *testing.T) {
+	t.Parallel()
+	got := CallServerStream(context.Background(), func(context.Context) (grpc.ServerStreamingClient[int], error) {
+		return nil, nil
+	})
+	if !errors.Is(got.Err, ErrNilStream{}) {
+		t.Fatalf("Err = %v, want %v", got.Err, ErrNilStream{})
+	}
+	if len(got.Messages) != 0 {
+		t.Fatalf("Messages = %v, want empty", got.Messages)
+	}
+	if got.TTFB != 0 {
+		t.Fatalf("TTFB = %v, want 0", got.TTFB)
+	}
+	if got.TotalDuration < 0 {
+		t.Fatalf("TotalDuration = %v, want non-negative", got.TotalDuration)
+	}
+}
+
 func TestCallServerStream_nilMessage(t *testing.T) {
 	t.Parallel()
 	got := CallServerStream(context.Background(), func(context.Context) (grpc.ServerStreamingClient[int], error) {
 		return &nilMessageServerStream{}, nil
 	})
-	if !errors.Is(got.Err, errNilStreamMessage) {
-		t.Fatalf("Err = %v, want %v", got.Err, errNilStreamMessage)
+	if !errors.Is(got.Err, ErrNilStreamMessage{}) {
+		t.Fatalf("Err = %v, want %v", got.Err, ErrNilStreamMessage{})
 	}
 	if len(got.Messages) != 0 {
 		t.Fatalf("Messages = %v, want empty", got.Messages)
@@ -398,6 +417,29 @@ func TestCallClientStream_zeroSendCloseAndRecv(t *testing.T) {
 	if got.TotalDuration < got.SendDuration+got.ResponseLatency {
 		t.Fatalf("TotalDuration = %v, want >= SendDuration(%v) + ResponseLatency(%v)",
 			got.TotalDuration, got.SendDuration, got.ResponseLatency)
+	}
+}
+
+func TestCallClientStream_openFnNilStream(t *testing.T) {
+	t.Parallel()
+	got := CallClientStream(context.Background(),
+		func(context.Context) (grpc.ClientStreamingClient[int, string], error) {
+			return nil, nil
+		},
+		func(grpc.ClientStreamingClient[int, string]) (string, error) {
+			t.Fatal("sendFn should not run")
+			return "", nil
+		},
+	)
+	if !errors.Is(got.Err, ErrNilStream{}) {
+		t.Fatalf("Err = %v, want %v", got.Err, ErrNilStream{})
+	}
+	if got.TotalDuration < 0 {
+		t.Fatalf("TotalDuration = %v, want non-negative", got.TotalDuration)
+	}
+	if got.SendDuration != 0 || got.ResponseLatency != 0 || got.MessagesSent != 0 {
+		t.Fatalf("unexpected timings: SendDuration=%v ResponseLatency=%v MessagesSent=%d",
+			got.SendDuration, got.ResponseLatency, got.MessagesSent)
 	}
 }
 


### PR DESCRIPTION
This commit introduces two new functions, `CallServerStream` and `CallClientStream`, to facilitate server-streaming and client-streaming RPCs in the evals package. The `CallServerStream` function captures messages, time-to-first-byte (TTFB), total duration, and inter-message intervals, while `CallClientStream` tracks send and response timing. Both functions enhance the framework's capabilities for handling streaming scenarios, ensuring accurate timing metrics and improved usability. Additionally, comprehensive documentation and tests have been added to validate the new functionality and provide usage examples.